### PR TITLE
fix url for libshared submodule repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/libshared"]
 	path = src/libshared
-	url = https://git.tasktools.org/scm/tm/libshared.git
+	url = https://github.com/GothenburgBitFactory/libshared.git


### PR DESCRIPTION
fixing url for libshared repo required for building holidata.

Sincerely,
Gour