### PR TITLE
Add support for regions

### DIFF
--- a/python/countries.py
+++ b/python/countries.py
@@ -51,8 +51,8 @@ class USA(Country):
     12-25: [NRF] Christmas Day
     3. monday in January:    [V] Birthday of Martin Luther King, Jr.
     3. monday in February:   [NV] Washington's Birthday
-    3. monday in April:      [NV] Patriot's day
-    1. last monday in May:   [NV] Memorial day
+    3. monday in April: [MA,ME] [NV] Patriots' Day
+    1. last monday in May:   [NV] Memorial Day
     1. monday in September:  [NV] Labor Day
     2. monday in October:    [NV] Columbus Day
     4. thursday in November: [NV] Thanksgiving Day


### PR DESCRIPTION
- Regions can be specified by adding '[R1,R2,R2]' in front of flags
- A holiday is yielded for each given region
- If no region is specified, a single holiday with region "" is yielded