### PR TITLE
Add Python code for calculating Icelandic holidays

### DIFF
--- a/python/holidays/__init__.py
+++ b/python/holidays/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "fr-BE",
     "fr-FR",
     "hr-HR",
+    "is-IS",
     "it-IT",
     "nb-NO",
     "nl-BE",

--- a/python/holidays/is-IS.py
+++ b/python/holidays/is-IS.py
@@ -1,0 +1,62 @@
+from dateutil.easter import EASTER_WESTERN
+
+from utils import SmartDayArrow
+from .holidays import Holiday, Locale
+
+
+class en_GB(Locale):
+    """
+    01-01: [NRF] Nýársdagur
+    3 days before Easter: [NRV] Skírdagur
+    2 days before Easter: [NRV] Föstudagurinn langi
+    Easter: [NRV] Páskadagur
+    1 day after Easter: [NRV] Annar dagur páska
+    39 days after Easter: [NRV] Uppstigningardagur
+    49 days after Easter: [NRV] Hvítasunnudagur
+    50 days after Easter: [NRV] Annar dagur hvítasunnu
+    05-01: [NF] Verkalýðsdagurinn
+    06-17: [NF] þjóðhátíðardagurinn
+    1. monday in August: [NV] Frídagur verslunarmanna
+    12-25: [NRF] Christmas Day
+    12-26: [NRF] Annar dagur jóla
+    """
+
+    locale = "is-IS"
+    easter_type = EASTER_WESTERN
+
+    def holiday_first_day_of_summer(self):
+        """
+        Calculate sumardagurinn fyrsti (first day of summer).
+
+        The holiday falls on the first Thursday after the 18th of April.
+        """
+        return [
+            Holiday(
+                locale=self.locale,
+                region="",
+                date=SmartDayArrow(self.year, 4, 18).shift_to_weekday("thursday"),
+                description="Sumardagurinn fyrsti",
+                flags="NV",
+                notes="",
+            )
+        ]
+
+    def holiday_half_days(self):
+        return [
+            Holiday(
+                locale=self.locale,
+                region="",
+                date=SmartDayArrow(self.year, 12, 24),
+                description="Aðfangadagur",
+                flags="NRF",
+                notes="Holiday from 13:00",
+            ),
+            Holiday(
+                locale=self.locale,
+                region="",
+                date=SmartDayArrow(self.year, 12, 31),
+                description="Gamlársdagur",
+                flags="NRF",
+                notes="Holiday from 13:00",
+            ),
+        ]

--- a/python/holidays/is-IS.py
+++ b/python/holidays/is-IS.py
@@ -4,7 +4,7 @@ from utils import SmartDayArrow
 from .holidays import Holiday, Locale
 
 
-class en_GB(Locale):
+class is_IS(Locale):
     """
     01-01: [NRF] Nýársdagur
     3 days before Easter: [NRV] Skírdagur

--- a/python/holidays/is-IS.py
+++ b/python/holidays/is-IS.py
@@ -51,7 +51,7 @@ class is_IS(Locale):
         note.
 
         12-24: [NRF] Aðfangadagur jóla
-        12-31: [NRF] Gamlársdagur
+        12-31: [NF] Gamlársdagur
         """
         return [
             Holiday(
@@ -67,7 +67,7 @@ class is_IS(Locale):
                 region="",
                 date=SmartDayArrow(self.year, 12, 31),
                 description="Gamlársdagur",
-                flags="NRF",
+                flags="NF",
                 notes="Holiday from 13:00",
             ),
         ]

--- a/python/holidays/is-IS.py
+++ b/python/holidays/is-IS.py
@@ -42,6 +42,17 @@ class is_IS(Locale):
         ]
 
     def holiday_half_days(self):
+        """
+        Define half-day holidays.
+
+        Both Christmas Eve (_aðfangadagur_) and New Year's Eve
+        (_gamlársdagur_) are public holidays in Iceland from 13:00 only.
+        They're included as full-day holidays, but with an explanatory
+        note.
+
+        12-24: [NRF] Aðfangadagur
+        12-31: [NRF] Gamlársdagur
+        """
         return [
             Holiday(
                 locale=self.locale,

--- a/python/holidays/is-IS.py
+++ b/python/holidays/is-IS.py
@@ -15,7 +15,7 @@ class is_IS(Locale):
     49 days after Easter: [NRV] Hvítasunnudagur
     50 days after Easter: [NRV] Annar dagur hvítasunnu
     05-01: [NF] Verkalýðsdagurinn
-    06-17: [NF] þjóðhátíðardagurinn
+    06-17: [NF] Þjóðhátíðardagurinn
     1. monday in August: [NV] Frídagur verslunarmanna
     12-25: [NRF] Jóladagur
     12-26: [NRF] Annar dagur jóla

--- a/python/holidays/is-IS.py
+++ b/python/holidays/is-IS.py
@@ -17,7 +17,7 @@ class is_IS(Locale):
     05-01: [NF] Verkalýðsdagurinn
     06-17: [NF] þjóðhátíðardagurinn
     1. monday in August: [NV] Frídagur verslunarmanna
-    12-25: [NRF] Christmas Day
+    12-25: [NRF] Jóladagur
     12-26: [NRF] Annar dagur jóla
     """
 

--- a/python/holidays/is-IS.py
+++ b/python/holidays/is-IS.py
@@ -45,12 +45,12 @@ class is_IS(Locale):
         """
         Define half-day holidays.
 
-        Both Christmas Eve (_aðfangadagur_) and New Year's Eve
+        Both Christmas Eve (_aðfangadagur jóla_) and New Year's Eve
         (_gamlársdagur_) are public holidays in Iceland from 13:00 only.
         They're included as full-day holidays, but with an explanatory
         note.
 
-        12-24: [NRF] Aðfangadagur
+        12-24: [NRF] Aðfangadagur jóla
         12-31: [NRF] Gamlársdagur
         """
         return [
@@ -58,7 +58,7 @@ class is_IS(Locale):
                 locale=self.locale,
                 region="",
                 date=SmartDayArrow(self.year, 12, 24),
-                description="Aðfangadagur",
+                description="Aðfangadagur jóla",
                 flags="NRF",
                 notes="Holiday from 13:00",
             ),


### PR DESCRIPTION
This new locale calculates public holidays in Iceland as set down in the two relevant laws.

The first is [_Lög um 40 stunda vinnuviku_](https://www.althingi.is/lagas/149c/1971088.html) (Act on a 40-hour working week). Article 6 defines public holidays as:

- Holy days of the National Church of Iceland
- First Day of Summer (_sumardagurinn fyrsti_)
- 1st of May, Labour Day (_verkalýðsdagurinn_)
- 17th of June, Icelandic National Day (_þjóðhátíðardagurinn_)
- First Monday in August (_frídagur verslunarmanna_)
- Christmas Eve (_aðfangadagur_) — but only from 13:00
- New Year's Eve (_gamlársdagur_) — but only from 13:00

The second law, [_Lög um frið vegna helgihalds_](https://www.althingi.is/lagas/149c/1997032.html) (Act on holidays due to holy days), defines the holidays of the National Church of Iceland as:

- New Year's Day (_nýársdagur_)
- Maundy Thursday (_skírdagur_)
- Good Friday (_föstudagurinn langi_)
- Easter Sunday (_páskadagur_)
- Easter Monday (_annar dagur páska_)
- Ascension (_uppstigningardagur_)
- Whitsun (_hvítasunnudagur_)
- Whit Monday (_annar dagur hvítasunnu_)
- Christmas Eve (_aðfangadagur jóla_) — but only from 18:00
- Christmas Day (_jóladagur_)
- Boxing Day (_annar dagur jóla_)

The only wrinkle is that Christmas Eve and New Year's Eve are half-day holidays, from 13:00. Because [`holidata`](https://github.com/GothenburgBitFactory/holidata) doesn't support partial days I've included them as full days (many businesses do give people the whole day as a holiday).

Fixes: https://github.com/GothenburgBitFactory/holidata/issues/25