### PR TITLE
Add locale sv-SE

### DIFF
--- a/holidata/holidays/__init__.py
+++ b/holidata/holidays/__init__.py
@@ -31,4 +31,5 @@ __all__ = [
     "ru-RU",
     "sk-SK",
     "sv-FI",
+    "sv-SE",
 ]

--- a/holidata/holidays/sv-SE.py
+++ b/holidata/holidays/sv-SE.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+from dateutil.easter import EASTER_WESTERN
+
+from holidata.utils import SmartDayArrow
+from .holidays import Locale, Holiday
+
+"""
+source: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253
+source: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/semesterlag-1977480_sfs-1977-480
+"""
+
+
+class sv_SE(Locale):
+    """
+    01-01: [NF] Nyårsdagen
+    01-06: [NRF] Trettondedag jul
+    05-01: [NF] Första maj
+    06-06: [NF] Nationaldagen
+    12-24: [NRF] Julafton
+    12-25: [NRF] Juldagen
+    12-26: [NRF] Annandag jul
+    12-31: [NF] Nyårsafton
+    2 days before Easter: [NRV] Långfredagen
+    Easter: [NRV] Påskdagen
+    1 day after Easter: [NRV] Annandag påsk
+    39 days after Easter: [NRV] Kristi himmelsfärdsdag
+    49 days after Easter: [NRV] Pingstdagen
+    """
+
+    locale = "sv-SE"
+    easter_type = EASTER_WESTERN
+
+    def __midsommar(self):
+        """
+        Find the Saturday between 20 and 26 June
+        """
+        return SmartDayArrow(self.year, 6, 19).shift_to_weekday('saturday', order=1, reverse=False)
+
+
+    def holiday_midsommarafton(self):
+        """
+        The day before midsommardagen: [NV] Midsommarafton
+        """
+        return [Holiday(
+            self.locale,
+            "",
+            self.__midsommar().shift(days=-1),
+            "Midsommarafton",
+            "NV"
+        )]
+
+    def holiday_midsommardagen(self):
+        """
+        Saturday between 20 and 26 June: [NV] Midsommardagen
+        """
+        return [Holiday(
+            self.locale,
+            "",
+            self.__midsommar(),
+            "Midsommardagen",
+            "NV"
+        )]
+
+    def holiday_alla_helgons_dag(self):
+        """
+        Saturday between 31 October and 6 November: [NRV] Alla helgons dag
+        """
+        return [Holiday(
+            self.locale,
+            "",
+            SmartDayArrow(self.year, 10, 30).shift_to_weekday('saturday', order=1, reverse=False),
+            "Alla helgons dag",
+            "NRV"
+        )]

--- a/tests/snapshots/snap_test_holidata.py
+++ b/tests/snapshots/snap_test_holidata.py
@@ -644,3 +644,25 @@ snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_FI-2019] 1'] =
 snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_FI-2020] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_FI-2020] 1.py')
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_FI-2021] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_FI-2021] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2011] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2012] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2013] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2013] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2014] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2014] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2015] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2015] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2016] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2016] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2017] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2017] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2018] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2018] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2019] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2019] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2020] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2020] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_SE-2021] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2021] 1.py')

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2011] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2011] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2011-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-04-22',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-24',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-25',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-06-02',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-06-12',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-06-24',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2011-06-25',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2011-11-05',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2012] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2012] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2012-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-04-06',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-08',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-09',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-05-17',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-05-27',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-06-22',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2012-06-23',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2012-11-03',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2013] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2013] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2013-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-03-29',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-03-31',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-04-01',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-05-09',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-05-19',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-06-21',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2013-06-22',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2013-11-02',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2014] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2014] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2014-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-04-18',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-20',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-21',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-05-29',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-06-08',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-06-20',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2014-06-21',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2014-11-01',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2015] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2015] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2015-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-04-03',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-05',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-06',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-05-14',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-05-24',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-06-19',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2015-06-20',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2015-10-31',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2016] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2016] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2016-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-03-25',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-03-27',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-03-28',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-05',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-05-15',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-06-24',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2016-06-25',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2016-11-05',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2017] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2017] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2017-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-04-14',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-16',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-17',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-05-25',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-06-04',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-06-23',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2017-06-24',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2017-11-04',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2018] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2018] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2018-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-03-30',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-01',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-02',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-10',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-05-20',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-06-22',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2018-06-23',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2018-11-03',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2019] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2019] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2019-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-04-19',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-21',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-22',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-05-30',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-06-09',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-06-21',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2019-06-22',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2019-11-02',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2020] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2020-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-04-10',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-12',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-13',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-05-21',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-05-31',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-06-19',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2020-06-20',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2020-10-31',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_SE-2021] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2021-01-01',
+        'description': 'Nyårsdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-01-06',
+        'description': 'Trettondedag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-04-02',
+        'description': 'Långfredagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-04',
+        'description': 'Påskdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-05',
+        'description': 'Annandag påsk',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-05-01',
+        'description': 'Första maj',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-05-13',
+        'description': 'Kristi himmelsfärdsdag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-05-23',
+        'description': 'Pingstdagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-06-06',
+        'description': 'Nationaldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-06-25',
+        'description': 'Midsommarafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2021-06-26',
+        'description': 'Midsommardagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NV'
+    },
+    {
+        'date': '2021-11-06',
+        'description': 'Alla helgons dag',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-12-24',
+        'description': 'Julafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-12-25',
+        'description': 'Juldagen',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-12-26',
+        'description': 'Annandag jul',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-12-31',
+        'description': 'Nyårsafton',
+        'locale': 'sv-SE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]


### PR DESCRIPTION
Closes #19.

This adds all the holidays based on [1989:253](https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253). As @pxtimes3 pointed out in #19 – where a short list of dates was posted – there are a number of “_afton_” (english: eve) days on some lists that do not have a basis in this law.

**However** I did chose to include _julafton_, _midsommarafton_, and _nyårasfton_, because these are specifically defined by law to be Sundays. Specifically by [1977:480 § 3 a ¶ 2](https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/semesterlag-1977480_sfs-1977-480#P3a). Because Holidata lists dates “on which business or work are suspended or reduced”, and many businesses treat these days as weekends, I felt it made sense to include them.

This is a different law. Vacation law rather than national holidays. And I was not sure if Holidata wanted to separate the two. For separation sake I have not marked these three days as `[N]`. May that be a valid solution? How have other countries handled this?