### PR TITLE
Add locale hu-HU

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- #59 Add locale for hu-HU
+      (Thanks to David Hanak)
 - #60 Add locale for tr-TR
       (Thanks to farukara)
 - #55 Fixed: Wrong assignment of flag `N` in locales en-US and es-US

--- a/holidata/holidays/__init__.py
+++ b/holidata/holidays/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "fr-CA",
     "fr-FR",
     "hr-HR",
+    "hu-HU",
     "is-IS",
     "it-IT",
     "nb-NO",

--- a/holidata/holidays/hu-HU.py
+++ b/holidata/holidays/hu-HU.py
@@ -1,0 +1,239 @@
+# coding=utf-8
+from dateutil.easter import EASTER_WESTERN
+
+from holidata.utils import easter, SmartDayArrow
+from .holidays import Locale, Holiday
+
+"""
+sources:
+- Hungarian Constitution - Article J (1)
+  https://www.keh.hu/magyarorszag_alaptorvenye/1515-Magyarorszag_Alaptorvenye
+- 2017. évi XIII. törvény egyes törvényeknek a nagypéntek munkaszüneti nappá történő nyilvánításával összefüggő módosításáról
+  https://mkogy.jogtar.hu/jogszabaly?docid=A1700013.TV
+"""
+
+
+class hu_HU(Locale):
+    """
+    01-01: [NF] Újév
+    03-15: [NF] Az 1848-as forradalom ünnepe
+    05-01: [NF] A munka ünnepe
+    08-20: [NF] Az államalapítás ünnepe
+    10-23: [NF] Az 1956-os forradalom ünnepe
+    11-01: [NRF] Mindenszentek
+    12-25: [NRF] Karácsony
+    12-26: [NRF] Karácsony
+    Easter: [NRV] Húsvét
+    1 day after Easter: [NRV] Húsvéthétfő
+    49 days after Easter: [NRV] Pünkösd
+    50 days after Easter: [NRV] Pünkösdhétfő
+    """
+
+    locale = "hu-HU"
+    easter_type = EASTER_WESTERN
+
+    def holiday_nagypentek(self):
+        """
+        2 days before Easter: [NRV] Nagypéntek (since 2017)
+        """
+        if self.year >= 2017:
+            return [Holiday(
+                self.locale,
+                "",
+                easter(self.year, self.easter_type).shift(days=-2),
+                "Nagypéntek",
+                "NRV"
+            )]
+        else:
+            return []
+
+    def holiday_munkaszuneti_nap(self):
+        """
+        Non-Working days (Munkaszüneti nap)
+        When a public holiday falls on a Tuesday or a Thursday, a special decree swaps the preceding Monday or the
+        following Friday (respectively) with a not too distant Saturday
+        2015: 28/2014. (IX.   24.) NGM rendelet a 2015. évi munkaszüneti napok körüli munkarendről
+        2016:  8/2015. (VI.   29.) NGM rendelet a 2016. évi munkaszüneti napok körüli munkarendről
+        2018:  9/2017. (V.    19.) NGM rendelet a 2018. évi munkaszüneti napok körüli munkarendről
+        2019:  6/2018. (VIII. 23.) PM  rendelet a 2019. évi munkaszüneti napok körüli munkarendről
+        2020:  7/2019. (VI.   25.) PM  rendelet a 2020. évi munkaszüneti napok körüli munkarendről
+        2021: 14/2020. (V.    13.) ITM rendelet a 2021. évi munkaszüneti napok körüli munkarendről
+        """
+        if self.year == 2015:
+            """
+            01-02, swapped with 01-10
+            08-21, swapped with 08-08
+            12-24, swapped with 12-12
+            """
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 1, 2),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2015-01-10 pihenőnap"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 8, 21),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2015-08-08 pihenőnap"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 12, 24),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2015-12-12 pihenőnap"
+                )]
+        if self.year == 2016:
+            """
+            03-14, swapped with 03-05
+            10-31, swapped with 10-15
+            """
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 3, 14),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2016-03-05 pihenőnap"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 10, 31),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2016-10-15 pihenőnap"
+                )]
+        if self.year == 2018:
+            """
+            03-16, swapped with 03-10
+            04-30, swapped with 04-21
+            10-22, swapped with 10-13
+            11-02, swapped with 11-10
+            12-24, swapped with 12-01
+            12-31, swapped with 12-15
+            """
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 3, 16),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="Swapped with 03-10"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 4, 30),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="Swapped with 04-21"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 10, 22),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="Swapped with 10-13"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 11, 2),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="Swapped with 11-10"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 12, 24),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="Swapped with 12-01"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 12, 31),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="Swapped with 12-15"
+                )]
+        if self.year == 2019:
+            """
+            08-19, swapped with 08-10
+            12-24, swapped with 12-07
+            12-27, swapped with 12-14
+            """
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 8, 19),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2019-08-10 pihenőnap"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 12, 24),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2019-12-07 pihenőnap"
+                ),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 12, 27),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2019-12-14 pihenőnap"
+                )]
+        if self.year == 2020:
+            """
+            08-21, swapped with 08-29
+            12-24, swapped with 12-12
+            """
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 8, 21),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2020-08-29 pihenőnap"),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 12, 24),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2020-12-12 pihenőnap"
+                )]
+        if self.year == 2021:
+            """
+            12-24, swapped with 12-11
+            """
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 12, 24),
+                    description="Munkaszüneti Nap",
+                    flags="NF",
+                    notes="2021-12-11 pihenőnap"
+                )]
+
+        return []

--- a/tests/snapshots/snap_test_holidata.py
+++ b/tests/snapshots/snap_test_holidata.py
@@ -688,3 +688,25 @@ snapshots['test_holidata_produces_holidays_for_locale_and_year[tr_TR-2019] 1'] =
 snapshots['test_holidata_produces_holidays_for_locale_and_year[tr_TR-2020] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[tr_TR-2020] 1.py')
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[tr_TR-2021] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[tr_TR-2021] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2011] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2012] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2013] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2013] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2014] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2014] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2015] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2015] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2016] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2016] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2017] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2017] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2018] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2018] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2019] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2019] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2020] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2020] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[hu_HU-2021] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2021] 1.py')

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2011] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2011] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2011-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-04-24',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-25',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-06-12',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-06-13',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2012] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2012] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2012-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-04-08',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-09',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-05-27',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-05-28',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2013] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2013] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2013-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-03-31',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-04-01',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-05-19',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-05-20',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2014] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2014] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2014-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-04-20',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-21',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-06-08',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-06-09',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2015] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2015] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2015-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-01-02',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2015-01-10 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-04-05',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-06',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-05-24',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-05-25',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-08-21',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2015-08-08 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-12-24',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2015-12-12 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2016] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2016] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2016-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-03-14',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2016-03-05 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-03-27',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-03-28',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-15',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-05-16',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-10-31',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2016-10-15 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2017] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2017] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2017-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-04-14',
+        'description': 'Nagypéntek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-16',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-17',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-06-04',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-06-05',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2018] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2018] 1.py
@@ -1,0 +1,154 @@
+[
+    {
+        'date': '2018-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-03-16',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': 'Swapped with 03-10',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-03-30',
+        'description': 'Nagypéntek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-01',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-02',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-30',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': 'Swapped with 04-21',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-20',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-05-21',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-10-22',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': 'Swapped with 10-13',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-11-02',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': 'Swapped with 11-10',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-24',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': 'Swapped with 12-01',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-12-31',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': 'Swapped with 12-15',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2019] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2019] 1.py
@@ -1,0 +1,130 @@
+[
+    {
+        'date': '2019-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-04-19',
+        'description': 'Nagypéntek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-21',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-22',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-06-09',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-06-10',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-08-19',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2019-08-10 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-12-24',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2019-12-07 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-12-27',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2019-12-14 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2020] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2020-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-04-10',
+        'description': 'Nagypéntek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-12',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-13',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-05-31',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-06-01',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-08-21',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2020-08-29 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-12-24',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2020-12-12 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2021] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2021-01-01',
+        'description': 'Újév',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-03-15',
+        'description': 'Az 1848-as forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-04-02',
+        'description': 'Nagypéntek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-04',
+        'description': 'Húsvét',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-05',
+        'description': 'Húsvéthétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-05-01',
+        'description': 'A munka ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-05-23',
+        'description': 'Pünkösd',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-05-24',
+        'description': 'Pünkösdhétfő',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-08-20',
+        'description': 'Az államalapítás ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-10-23',
+        'description': 'Az 1956-os forradalom ünnepe',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-11-01',
+        'description': 'Mindenszentek',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-12-24',
+        'description': 'Munkaszüneti Nap',
+        'locale': 'hu-HU',
+        'notes': '2021-12-11 pihenőnap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-25',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-12-26',
+        'description': 'Karácsony',
+        'locale': 'hu-HU',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    }
+]


### PR DESCRIPTION
This adds the locale hu-HU, holidays for Hungary.

Please review for typos and errors.
The decreed holidays for 2015, 2016, 2018, and 2019 require the respective decrees to be verified.
Holiday `Nagypéntek` requires the decree which made it an official holiday since 2017