### PR TITLE
Update locale hr-HR

### DIFF
--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -7,6 +7,7 @@ from .holidays import Locale, Holiday
 """
 sources
 THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
+2006: https://narodne-novine.nn.hr/eli/sluzbeni/2006/59/1428
 2005: https://narodne-novine.nn.hr/eli/sluzbeni/2005/112/2062
 2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/136/2194
 2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/13/318

--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -7,7 +7,9 @@ from .holidays import Locale, Holiday
 """
 sources
 THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
-2008: https://narodne-novine.nn.hr/eli/sluzbeni/2008/55/1911 (no changes)
+2011: https://narodne-novine.nn.hr/eli/sluzbeni/2011/130/2613 (no changes)
+2011: https://narodne-novine.nn.hr/eli/sluzbeni/2011/74/1576 (no changes)
+2008: https://narodne-novine.nn.hr/eli/sluzbeni/2008/55/1911
 2006: https://narodne-novine.nn.hr/eli/sluzbeni/2006/59/1428 (no changes)
 2005: https://narodne-novine.nn.hr/eli/sluzbeni/2005/112/2062 (no changes)
 2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/136/2194

--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -7,6 +7,7 @@ from .holidays import Locale, Holiday
 """
 sources
 THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
+2019: https://narodne-novine.nn.hr/eli/sluzbeni/2019/110/2212
 2011: https://narodne-novine.nn.hr/eli/sluzbeni/2011/130/2613 (no changes)
 2011: https://narodne-novine.nn.hr/eli/sluzbeni/2011/74/1576 (no changes)
 2008: https://narodne-novine.nn.hr/eli/sluzbeni/2008/55/1911
@@ -21,14 +22,11 @@ THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
 
 class hr_HR(Locale):
     """
-    01-01: [NF] Nova godina
-    01-06: [NRF] Bogojavljanje
+    01-01: [NF] Nova Godina
+    01-06: [NRF] Bogojavljenje
     05-01: [NF] Praznik rada
     06-22: [NF] Dan antifašističke borbe
-    06-25: [NF] Dan državnosti
-    08-05: [NF] Dan pobjede i domovinske zahvalnosti
     08-15: [NRF] Velika Gospa
-    10-08: [NF] Dan neovisnosti
     11-01: [NRF] Svi sveti
     12-25: [NRF] Božić
     12-26: [NRF] Sveti Stjepan
@@ -39,6 +37,46 @@ class hr_HR(Locale):
 
     locale = "hr-HR"
     easter_type = EASTER_WESTERN
+
+    def holiday_dan_neovisnosti(self):
+        if self.year < 2020:
+            return [Holiday(
+                self.locale,
+                "",
+                SmartDayArrow(self.year, 10, 8),
+                "Dan neovisnosti",
+                "NF"
+            )]
+        else:
+            return []
+
+    def holiday_dan_pobjede_i_domovinske_zahvalnosti_i_dan_hrvatskih_branitelja(self):
+        if self.year >= 2008:
+            name = "Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja"
+        else:
+            name = "Dan pobjede i domovinske zahvalnosti"
+
+        return [Holiday(
+            self.locale,
+            "",
+            SmartDayArrow(self.year, 8, 5),
+            name,
+            "NF"
+        )]
+
+    def holiday_dan_drzavnosti(self):
+        if self.year >= 2020:
+            date = SmartDayArrow(self.year, 5, 30)
+        else:
+            date = SmartDayArrow(self.year, 6, 25)
+
+        return [Holiday(
+            self.locale,
+            "",
+            date,
+            "Dan državnosti",
+            "NF"
+        )]
 
     def holiday_dan_sjecanja_na_zrtve_domovinskog_rata_i_dan_sjecanja_na_zrtvu_vukovara_i_skabrnje(self):
         if self.year >= 2020:

--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -7,6 +7,7 @@ from .holidays import Locale, Holiday
 """
 sources
 THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
+2001: https://narodne-novine.nn.hr/eli/sluzbeni/2001/96/1614
 1996: https://narodne-novine.nn.hr/eli/sluzbeni/1996/33/674
 """
 
@@ -14,17 +15,18 @@ THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
 class hr_HR(Locale):
     """
     01-01: [NF] Nova godina
-    01-06: [NRF] Sveta tri kralja
-    05-01: [NF] Blagdan rada
-    05-30: [NF] Dan državnosti
+    05-01: [NF] Praznik rada
     06-22: [NF] Dan antifašističke borbe
-    08-05: [NF] Dan domovinske zahvalnosti
+    06-25: [NF] Dan državnosti
+    08-05: [NF] Dan pobjede i domovinske zahvalnosti
     08-15: [NRF] Velika Gospa
+    10-08: [NF] Dan neovisnosti
     11-01: [NRF] Svi sveti
     12-25: [NRF] Božić
     12-26: [NRF] Sveti Stjepan
     Easter: [NRV] Uskrs
     1 day after Easter: [NRV] Uskrsni ponedjeljak
+    60 days after Easter: [NRV] Tijelovo
     """
 
     locale = "hr-HR"

--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -7,8 +7,9 @@ from .holidays import Locale, Holiday
 """
 sources
 THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
-2006: https://narodne-novine.nn.hr/eli/sluzbeni/2006/59/1428
-2005: https://narodne-novine.nn.hr/eli/sluzbeni/2005/112/2062
+2008: https://narodne-novine.nn.hr/eli/sluzbeni/2008/55/1911 (no changes)
+2006: https://narodne-novine.nn.hr/eli/sluzbeni/2006/59/1428 (no changes)
+2005: https://narodne-novine.nn.hr/eli/sluzbeni/2005/112/2062 (no changes)
 2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/136/2194
 2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/13/318
 2001: https://narodne-novine.nn.hr/eli/sluzbeni/2001/96/1614

--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -4,22 +4,27 @@ from dateutil.easter import EASTER_WESTERN
 from holidata.utils import SmartDayArrow
 from .holidays import Locale, Holiday
 
+"""
+sources
+THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
+1996: https://narodne-novine.nn.hr/eli/sluzbeni/1996/33/674
+"""
+
 
 class hr_HR(Locale):
     """
-    01-01: [NF] Nova Godina
+    01-01: [NF] Nova godina
     01-06: [NRF] Sveta tri kralja
-    05-01: [NF] Praznik rada
+    05-01: [NF] Blagdan rada
     05-30: [NF] Dan državnosti
     06-22: [NF] Dan antifašističke borbe
-    08-05: [NF] Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja
+    08-05: [NF] Dan domovinske zahvalnosti
     08-15: [NRF] Velika Gospa
-    11-01: [NRF] Dan svih svetih
+    11-01: [NRF] Svi sveti
     12-25: [NRF] Božić
     12-26: [NRF] Sveti Stjepan
     Easter: [NRV] Uskrs
-    1 day after Easter: [NRV] Uskršnji ponedjeljak
-    60 days after Easter: [NRV] Tijelovo
+    1 day after Easter: [NRV] Uskrsni ponedjeljak
     """
 
     locale = "hr-HR"

--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -7,6 +7,8 @@ from .holidays import Locale, Holiday
 """
 sources
 THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
+2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/136/2194
+2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/13/318
 2001: https://narodne-novine.nn.hr/eli/sluzbeni/2001/96/1614
 1996: https://narodne-novine.nn.hr/eli/sluzbeni/1996/33/674
 """
@@ -15,6 +17,7 @@ THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
 class hr_HR(Locale):
     """
     01-01: [NF] Nova godina
+    01-06: [NRF] Bogojavljanje
     05-01: [NF] Praznik rada
     06-22: [NF] Dan antifašističke borbe
     06-25: [NF] Dan državnosti

--- a/src/holidata/holidays/hr-HR.py
+++ b/src/holidata/holidays/hr-HR.py
@@ -7,6 +7,7 @@ from .holidays import Locale, Holiday
 """
 sources
 THE LAW ON HOLIDAYS, MEMORIALS AND NON-WORKING DAYS IN THE REPUBLIC OF CROATIA
+2005: https://narodne-novine.nn.hr/eli/sluzbeni/2005/112/2062
 2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/136/2194
 2002: https://narodne-novine.nn.hr/eli/sluzbeni/2002/13/318
 2001: https://narodne-novine.nn.hr/eli/sluzbeni/2001/96/1614

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2011] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2011] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2011-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2011-04-25',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2011-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2011-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NRV'
     },
     {
+        'date': '2011-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2011-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2011-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2011-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2012] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2012] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2012-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2012-04-09',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2012-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2012-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2012-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2012-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2012-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2012-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2013] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2013] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2013-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2013-04-01',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2013-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2013-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2013-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2013-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2013-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2013-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2014] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2014] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2014-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2014-04-21',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2014-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2014-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2014-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2014-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2014-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2014-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2015] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2015] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2015-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2015-04-06',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2015-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2015-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2015-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2015-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2015-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2015-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2016] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2016] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2016-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2016-03-28',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -48,16 +48,16 @@
         'type': 'NRV'
     },
     {
-        'date': '2016-05-30',
-        'description': 'Dan državnosti',
+        'date': '2016-06-22',
+        'description': 'Dan antifašističke borbe',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
         'type': 'NF'
     },
     {
-        'date': '2016-06-22',
-        'description': 'Dan antifašističke borbe',
+        'date': '2016-06-25',
+        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2016-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2016-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2017] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2017] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2017-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2017-04-17',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2017-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2017-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2017-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2017-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2017-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2017-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2018] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2018] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2018-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2018-04-02',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2018-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2018-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2018-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2018-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2018-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2018-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2019] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2019] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2019-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2019-04-22',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2019-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2019-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2019-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2019-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2019-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2019-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2020] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2020-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2020-04-13',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2020-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2020-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2020-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2020-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2020-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2020-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2020] 1.py
@@ -40,6 +40,14 @@
         'type': 'NF'
     },
     {
+        'date': '2020-05-30',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2020-06-11',
         'description': 'Tijelovo',
         'locale': 'hr-HR',
@@ -50,14 +58,6 @@
     {
         'date': '2020-06-22',
         'description': 'Dan antifašističke borbe',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2020-06-25',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -78,14 +78,6 @@
         'notes': '',
         'region': '',
         'type': 'NRF'
-    },
-    {
-        'date': '2020-10-08',
-        'description': 'Dan neovisnosti',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
     },
     {
         'date': '2020-11-01',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2021] 1.py
@@ -9,7 +9,7 @@
     },
     {
         'date': '2021-01-06',
-        'description': 'Sveta tri kralja',
+        'description': 'Bogojavljenje',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -25,7 +25,7 @@
     },
     {
         'date': '2021-04-05',
-        'description': 'Uskršnji ponedjeljak',
+        'description': 'Uskrsni ponedjeljak',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -34,14 +34,6 @@
     {
         'date': '2021-05-01',
         'description': 'Praznik rada',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2021-05-30',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -64,6 +56,14 @@
         'type': 'NF'
     },
     {
+        'date': '2021-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2021-08-05',
         'description': 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja',
         'locale': 'hr-HR',
@@ -80,8 +80,16 @@
         'type': 'NRF'
     },
     {
+        'date': '2021-10-08',
+        'description': 'Dan neovisnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2021-11-01',
-        'description': 'Dan svih svetih',
+        'description': 'Svi sveti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hr_HR-2021] 1.py
@@ -40,6 +40,14 @@
         'type': 'NF'
     },
     {
+        'date': '2021-05-30',
+        'description': 'Dan državnosti',
+        'locale': 'hr-HR',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2021-06-03',
         'description': 'Tijelovo',
         'locale': 'hr-HR',
@@ -50,14 +58,6 @@
     {
         'date': '2021-06-22',
         'description': 'Dan antifašističke borbe',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
-    },
-    {
-        'date': '2021-06-25',
-        'description': 'Dan državnosti',
         'locale': 'hr-HR',
         'notes': '',
         'region': '',
@@ -78,14 +78,6 @@
         'notes': '',
         'region': '',
         'type': 'NRF'
-    },
-    {
-        'date': '2021-10-08',
-        'description': 'Dan neovisnosti',
-        'locale': 'hr-HR',
-        'notes': '',
-        'region': '',
-        'type': 'NF'
     },
     {
         'date': '2021-11-01',


### PR DESCRIPTION
This PR updates the holidays for Croatia according to the legal documents found [here](https://narodne-novine.nn.hr/search.aspx?upit=BLAGDANIMA%2c+SPOMENDANIMA+I+NERADNIM+DANIMA&naslovi=da&sortiraj=1&kategorija=1&rpp=10&qtype=3&pretraga=da).

@gour There are some issues [related to your PR](https://github.com/GothenburgBitFactory/holidata/pull/72/files) which I cannot resolve as a non-native speaker. Maybe you can help me out?

### `Bogojav­lja­nje ili Sveta tri kra­lja`

Holidata only supports one name for a holiday, so usually the most common used if the legal documents do not define it exactly.
The testfiles had used `Bogojav­ljenje` (the legal documents use both), but is this the most used name? According to [Wikipedia](https://hr.wikipedia.org/wiki/Sveta_tri_kralja), `Sveta tri kralja` refers to the mythical figures, but not to the holiday itself...
Btw.: the legal documents use the term `Bogojav­lja­nje`, while Wikipedia redirects to `Bogojav­ljenje` when searching for it. Is this a typo in the legal documents/alternative spelling/...?

### `Svi sveti`

The legal documents use the notation `Svi sveti` (as does Wikipedia), [you refer to it](https://github.com/GothenburgBitFactory/holidata/pull/72/files#diff-5444177d54a0ebfbaf2ef28598d7c47b465116d5bc5b88785f39146706c66499R17) as `Dan svih svetih`. As far as I know `Dan` means `Day of`, so this would be the decision between `All Saints'` and `All Saints' Day`. I would assume Wikipedia uses the common notation, so I would go for that. What about the `h` at the end of `svetih`?

### `Uskrsni ponedjeljak`
In all legal documents I see it written as `Uskrsni ponedjeljak` but you wrote it as `Uskršni ponedjeljak`. Is there a difference/this a typo in the legal documents/...?


