### PR TITLE
Add locale sl-SI

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- #78 Add locale for sl-SI
+      (Thanks to Dejan Dezman)
 - #21 Update locale for pt-BR
       (Thanks to Adriano Correa)
 - #58 Update locale for es-ES

--- a/holidata/holidays/__init__.py
+++ b/holidata/holidays/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "pt-PT",
     "ru-RU",
     "sk-SK",
+    "sl-SI",
     "sv-FI",
     "sv-SE",
     "tr-TR",

--- a/holidata/holidays/sl-SI.py
+++ b/holidata/holidays/sl-SI.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+from dateutil.easter import EASTER_WESTERN
+
+from holidata.utils import SmartDayArrow
+from .holidays import Locale, Holiday
+
+"""
+sources: http://www.pisrs.si/Pis.web/pregledPredpisa?id=ZAKO865#
+"""
+
+class sl_SI(Locale):
+    """
+    01-01: [NF] Novo leto
+    02-08: [NF] Prešernov dan
+    04-27: [NF] Dan upora proti okupatorju
+    05-01: [NF] Praznik dela
+    05-02: [NF] Praznik dela
+    06-25: [NF] Dan državnosti
+    08-15: [NRF] Marijino vnebovzetje
+    10-31: [NRF] Dan reformacije
+    11-01: [NF] Dan spomina na mrtve
+    12-25: [NF] Božič
+    12-26: [NF] Dan samostojnosti in enotnosti
+    Easter: [NRV] Velikonočna nedelja
+    1 day after Easter: [NRV] Velikonočni ponedeljek
+    50 days after Easter: [NRV] Binkošti
+    """
+
+    locale = "sl-SI"
+    easter_type = EASTER_WESTERN
+
+    def holiday_novo_leto(self):
+        """
+        From 1955 until May 2012, when the National Assembly of Slovenia passed the Public Finance Balance Act,
+        2 January was a work-free day. It was reintroduced in 2017.
+        2012<: https://www.uradni-list.si/1/objava.jsp?sop=2012-01-1700
+        2016<: https://www.uradni-list.si/1/objava.jsp?sop=2016-01-3568
+        """
+        return [Holiday(
+            self.locale,
+            "",
+            SmartDayArrow(self.year, 1, 2),
+            "Novo leto",
+            "NF"
+        )] if self.year not in [2013, 2014, 2015, 2016] else []

--- a/tests/snapshots/snap_test_holidata.py
+++ b/tests/snapshots/snap_test_holidata.py
@@ -727,6 +727,30 @@ snapshots['test_holidata_produces_holidays_for_locale_and_year[sk_SK-2021] 1'] =
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[sk_SK-2022] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sk_SK-2022] 1.py')
 
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2011] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2012] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2013] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2013] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2014] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2014] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2015] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2015] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2016] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2016] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2017] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2017] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2018] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2018] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2019] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2019] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2020] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2020] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2021] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2021] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[sl_SI-2022] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2022] 1.py')
+
 snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_FI-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_FI-2011] 1.py')
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[sv_FI-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sv_FI-2012] 1.py')

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2011] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2011] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2011-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-04-24',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-25',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-06-13',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2011-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2012] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2012] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2012-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-04-08',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-09',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-05-28',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2012-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2013] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2013] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2013-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-03-31',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-04-01',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-05-20',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2013-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2014] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2014] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2014-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-04-20',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-21',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-06-09',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2014-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2015] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2015] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2015-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-04-05',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-06',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-05-25',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2015-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2016] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2016] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2016-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-03-27',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-03-28',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-16',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2016-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2017] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2017] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2017-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-04-16',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-17',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-06-05',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2017-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2018] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2018] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2018-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-04-01',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-02',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-21',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2018-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2019] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2019] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2019-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-04-21',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-22',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-06-10',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2019-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2020] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2020-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-04-12',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-13',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-06-01',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2020-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2021] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2021-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-04-04',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-05',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-05-24',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2021-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2022] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[sl_SI-2022] 1.py
@@ -1,0 +1,122 @@
+[
+    {
+        'date': '2022-01-01',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-01-02',
+        'description': 'Novo leto',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-02-08',
+        'description': 'Prešernov dan',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-04-17',
+        'description': 'Velikonočna nedelja',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-04-18',
+        'description': 'Velikonočni ponedeljek',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-04-27',
+        'description': 'Dan upora proti okupatorju',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-05-01',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-05-02',
+        'description': 'Praznik dela',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-06-06',
+        'description': 'Binkošti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-06-25',
+        'description': 'Dan državnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-08-15',
+        'description': 'Marijino vnebovzetje',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2022-10-31',
+        'description': 'Dan reformacije',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NRF'
+    },
+    {
+        'date': '2022-11-01',
+        'description': 'Dan spomina na mrtve',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-25',
+        'description': 'Božič',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-26',
+        'description': 'Dan samostojnosti in enotnosti',
+        'locale': 'sl-SI',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]


### PR DESCRIPTION
Add the locale `sl-SI` to holidata.

Before merging, the following has to be resolved:
- [x] Add official sources from the Government Gazette of the Republic of Slovenia for the holidays
- [x] Confirm correctness of the holiday names
- [x] Confirm that both, `01-01` and `01-02`, are called `novo leto` (New Year's Day)
- [x] Confirm that all holidays exept `01-02` have not changed since 2011

Closes #77 