### PR TITLE
Add locale en-ZA

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- #80 Add locale en-ZA
+      (Thanks to girtu)
 - #83 Update non-working days for 2022 in locale hu-HU
 - #81 Add locale et-EE
       (Thanks to h0adp0re)

--- a/holidata/holidays/__init__.py
+++ b/holidata/holidays/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "en-GB",
     "en-NZ",
     "en-US",
+    "en-ZA",
     "es-CO",
     "es-ES",
     "es-US",

--- a/holidata/holidays/en-ZA.py
+++ b/holidata/holidays/en-ZA.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+from dateutil.easter import EASTER_WESTERN
+
+from holidata.utils import SmartDayArrow
+from .holidays import Holiday, Locale
+
+"""
+Public Holidays Act (Act No 36 of 1994).
+sources: 
+https://www.gov.za/sites/default/files/gcis_document/201409/act36of1994.pdf
+https://www.gov.za/sites/default/files/gcis_document/201409/act48of1995.pdf
+"""
+
+
+class en_ZA(Locale):
+    """
+    12-25: [NF] Christmas Day
+    2 days before Easter: [NRV] Good Friday
+    1 day after Easter: [NRV] Family Day
+    """
+
+    locale = "en-ZA"
+    easter_type = EASTER_WESTERN
+
+    def holiday_new_years_day(self):
+        """01-01: [NF] New Year's Day"""
+        return self.get_holidays(SmartDayArrow(self.year, 1, 1), "New Year's Day")
+
+    def holiday_human_rights_day(self):
+        """03-21: [NF] Human Rights Day"""
+        return self.get_holidays(SmartDayArrow(self.year, 3, 21), "Human Rights Day")
+
+    def holiday_freedom_day(self):
+        """04-27: [NF] Freedom Day"""
+        return self.get_holidays(SmartDayArrow(self.year, 4, 27), "Freedom Day")
+
+    def holiday_workers_day(self):
+        """05-01: [NF] Worker's Day"""
+        return self.get_holidays(SmartDayArrow(self.year, 5, 1), "Worker's Day")
+
+    def holiday_youth_day(self):
+        """06-16: [NF] Youth Day"""
+        return self.get_holidays(SmartDayArrow(self.year, 6, 16), "Youth Day")
+
+    def holiday_national_womens_day(self):
+        """08-09: [NF] National Women's Day"""
+        return self.get_holidays(SmartDayArrow(self.year, 8, 9), "National Women's Day")
+
+    def holiday_heritage_day(self):
+        """09-24: [NF] Heritage Day"""
+        return self.get_holidays(SmartDayArrow(self.year, 9, 24), "Heritage Day")
+
+    def holiday_day_of_reconciliation(self):
+        """12-16: [NF] Day of Reconciliation"""
+        return self.get_holidays(SmartDayArrow(self.year, 12, 16), "Day of Reconciliation")
+
+    def holiday_day_of_goodwill(self):
+        """12-26: [NF] Day of Goodwill"""
+        return self.get_holidays(SmartDayArrow(self.year, 12, 26), "Day of Goodwill")
+
+    def get_holidays(self, original_date, description):
+        """
+        Applies section 2.1 of the Public Holidays Act (Act No 36 of 1994):
+        'Whenever any public holiday falls on a Sunday, the following Monday shall be a public holiday.'
+        """
+        if original_date.weekday() == "sunday":
+            supplement_date = original_date.shift(days=1)
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region='',
+                    date=original_date,
+                    description=description,
+                    flags="NF",
+                    notes=""),
+                Holiday(
+                    locale=self.locale,
+                    region='',
+                    date=supplement_date,
+                    description=description + " (Supplement)",
+                    flags="NF",
+                    notes="Supplement holiday")
+            ]
+        else:
+            return [Holiday(
+                locale=self.locale,
+                region='',
+                date=original_date,
+                description=description,
+                flags="NF",
+                notes="")]

--- a/tests/snapshots/snap_test_holidata.py
+++ b/tests/snapshots/snap_test_holidata.py
@@ -271,6 +271,30 @@ snapshots['test_holidata_produces_holidays_for_locale_and_year[en_US-2021] 1'] =
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[en_US-2022] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_US-2022] 1.py')
 
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2011] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2012] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2013] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2013] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2014] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2014] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2015] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2015] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2016] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2016] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2017] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2017] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2018] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2018] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2019] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2019] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2020] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2020] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2021] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2021] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[en_ZA-2022] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2022] 1.py')
+
 snapshots['test_holidata_produces_holidays_for_locale_and_year[es_CO-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[es_CO-2011] 1.py')
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[es_CO-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[es_CO-2012] 1.py')

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2011] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2011] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2011-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-04-22',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-25',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-05-02',
+        'description': "Worker's Day (Supplement)",
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2012] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2012] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2012-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-01-02',
+        'description': "New Year's Day (Supplement)",
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-04-06',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-09',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-17',
+        'description': 'Day of Reconciliation (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2013] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2013] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2013-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-03-29',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-04-01',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-06-17',
+        'description': 'Youth Day (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2014] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2014] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2014-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-04-18',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-21',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-04-28',
+        'description': 'Freedom Day (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2015] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2015] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2015-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-04-03',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-06',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-08-10',
+        'description': "National Women's Day (Supplement)",
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2016] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2016] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2016-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-03-25',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-03-28',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-02',
+        'description': "Worker's Day (Supplement)",
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2017] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2017] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2017-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-01-02',
+        'description': "New Year's Day (Supplement)",
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-04-14',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-17',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-09-25',
+        'description': 'Heritage Day (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2018] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2018] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2018-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-03-30',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-02',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-17',
+        'description': 'Day of Reconciliation (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2019] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2019] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2019-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-04-19',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-22',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-06-17',
+        'description': 'Youth Day (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2020] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2020-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-04-10',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-13',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-08-10',
+        'description': "National Women's Day (Supplement)",
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2021] 1.py
@@ -1,0 +1,114 @@
+[
+    {
+        'date': '2021-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-03-22',
+        'description': 'Human Rights Day (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-04-02',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-05',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-27',
+        'description': 'Day of Goodwill (Supplement)',
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2022] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[en_ZA-2022] 1.py
@@ -1,0 +1,106 @@
+[
+    {
+        'date': '2022-01-01',
+        'description': "New Year's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-03-21',
+        'description': 'Human Rights Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-04-15',
+        'description': 'Good Friday',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-04-18',
+        'description': 'Family Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-04-27',
+        'description': 'Freedom Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-05-01',
+        'description': "Worker's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-05-02',
+        'description': "Worker's Day (Supplement)",
+        'locale': 'en-ZA',
+        'notes': 'Supplement holiday',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-06-16',
+        'description': 'Youth Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-08-09',
+        'description': "National Women's Day",
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-09-24',
+        'description': 'Heritage Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-16',
+        'description': 'Day of Reconciliation',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-25',
+        'description': 'Christmas Day',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-26',
+        'description': 'Day of Goodwill',
+        'locale': 'en-ZA',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]


### PR DESCRIPTION
This adds the locale `en-ZA` (South Africa) according to the [_Public Holidays Act (Act No 36 of 1994)_](https://www.gov.za/sites/default/files/gcis_document/201409/act36of1994.pdf).

Before merging, the following has to be resolved:

- [x] Naming convention for compensatory holidays

By definition 2.1, _whenever any public holiday falls on a Sunday, the following Monday shall be a public holiday_. How is such a holiday then referred to? With the same name as the actual holiday? I take that the holiday itself is *not* shifted.