### PR TITLE
Add locale et-EE

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- #81 Add locale et-EE
+      (Thanks to h0adp0re)
 - #78 Add locale for sl-SI
       (Thanks to Dejan Dezman)
 - #21 Update locale for pt-BR

--- a/holidata/holidays/__init__.py
+++ b/holidata/holidays/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "es-CO",
     "es-ES",
     "es-US",
+    "et-EE",
     "fi-FI",
     "fr-BE",
     "fr-CA",

--- a/holidata/holidays/et-EE.py
+++ b/holidata/holidays/et-EE.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+from dateutil.easter import EASTER_WESTERN
+
+from .holidays import Locale
+
+
+class et_EE(Locale):
+    """
+    01-01: [NF] Uusaasta
+    02-24: [NF] Iseseisvuspäev, Eesti Vabariigi aastapäev
+    05-01: [NF] Kevadpüha
+    06-23: [NF] Võidupüha
+    06-24: [NF] Jaanipäev
+    08-20: [NF] Taasiseseisvumispäev
+    12-24: [NF] Jõululaupäev
+    12-25: [NF] Esimene jõulupüha
+    12-26: [NF] Teine jõulupüha
+    2 days before Easter: [NRV] Suur reede
+    Easter: [NRV] Ülestõusmispühade 1. püha
+    49 days after Easter: [NRV] Nelipühade 1. püha
+    """
+
+    locale = "et-EE"
+    easter_type = EASTER_WESTERN

--- a/tests/snapshots/snap_test_holidata.py
+++ b/tests/snapshots/snap_test_holidata.py
@@ -343,6 +343,30 @@ snapshots['test_holidata_produces_holidays_for_locale_and_year[es_US-2021] 1'] =
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[es_US-2022] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[es_US-2022] 1.py')
 
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2011] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2012] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2013] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2013] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2014] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2014] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2015] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2015] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2016] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2016] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2017] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2017] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2018] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2018] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2019] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2019] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2020] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2020] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2021] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2021] 1.py')
+
+snapshots['test_holidata_produces_holidays_for_locale_and_year[et_EE-2022] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2022] 1.py')
+
 snapshots['test_holidata_produces_holidays_for_locale_and_year[fi_FI-2011] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[fi_FI-2011] 1.py')
 
 snapshots['test_holidata_produces_holidays_for_locale_and_year[fi_FI-2012] 1'] = FileSnapshot('snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[fi_FI-2012] 1.py')

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2011] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2011] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2011-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-04-22',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-04-24',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-06-12',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2011-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2011-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2012] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2012] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2012-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-04-06',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-04-08',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-05-27',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2012-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2012-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2013] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2013] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2013-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-03-29',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-03-31',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-05-19',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2013-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2013-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2014] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2014] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2014-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-04-18',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-04-20',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-06-08',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2014-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2014-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2015] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2015] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2015-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-04-03',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-04-05',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-05-24',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2015-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2015-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2016] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2016] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2016-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-03-25',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-03-27',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-05-15',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2016-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2016-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2017] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2017] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2017-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-04-14',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-04-16',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-06-04',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2017-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2017-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2018] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2018] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2018-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-03-30',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-04-01',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-05-20',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2018-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2018-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2019] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2019] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2019-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-04-19',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-04-21',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-06-09',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2019-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2019-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2020] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2020-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-04-10',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-04-12',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-05-31',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2020-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2020-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2021] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2021-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-04-02',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-04-04',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-05-23',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2021-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2021-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2022] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[et_EE-2022] 1.py
@@ -1,0 +1,98 @@
+[
+    {
+        'date': '2022-01-01',
+        'description': 'Uusaasta',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-02-24',
+        'description': 'Iseseisvuspäev, Eesti Vabariigi aastapäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-04-15',
+        'description': 'Suur reede',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-04-17',
+        'description': 'Ülestõusmispühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-05-01',
+        'description': 'Kevadpüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-06-05',
+        'description': 'Nelipühade 1. püha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NRV'
+    },
+    {
+        'date': '2022-06-23',
+        'description': 'Võidupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-06-24',
+        'description': 'Jaanipäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-08-20',
+        'description': 'Taasiseseisvumispäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-24',
+        'description': 'Jõululaupäev',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-25',
+        'description': 'Esimene jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-12-26',
+        'description': 'Teine jõulupüha',
+        'locale': 'et-EE',
+        'notes': '',
+        'region': '',
+        'type': 'NF'
+    }
+]


### PR DESCRIPTION
This adds the locale `et-EE` (Estonia) according to the [Public Holidays and Days of National Importance Act
](https://www.riigiteataja.ee/en/eli/ee/513112013017/consolide) ([Pühade ja tähtpäevade seadus](https://www.riigiteataja.ee/akt/109032011007))

Before merging, the following has to be resolved:

- [x] Have there been any changes to the listed holidays since 2011?
- [x] _Ülestõusmispühade 1. püha_ refers to Easter Sunday
- [x] _Nelipühade_ refers to Pentecost Sunday
