### PR TITLE
Update non-working days for 2022 in locale hu-HU

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- #83 Update non-working days for 2022 in locale hu-HU
 - #81 Add locale et-EE
       (Thanks to h0adp0re)
 - #78 Add locale for sl-SI

--- a/holidata/holidays/hu-HU.py
+++ b/holidata/holidays/hu-HU.py
@@ -71,25 +71,25 @@ class hu_HU(Locale):
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 1, 2),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2015-01-10 pihenőnap"
+                    notes="2015-01-10 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 8, 21),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2015-08-08 pihenőnap"
+                    notes="2015-08-08 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 12, 24),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2015-12-12 pihenőnap"
+                    notes="2015-12-12 munkanap"
                 )]
         if self.year == 2016:
             """
@@ -101,17 +101,17 @@ class hu_HU(Locale):
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 3, 14),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2016-03-05 pihenőnap"
+                    notes="2016-03-05 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 10, 31),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2016-10-15 pihenőnap"
+                    notes="2016-10-15 munkanap"
                 )]
         if self.year == 2018:
             """
@@ -127,49 +127,49 @@ class hu_HU(Locale):
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 3, 16),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="Swapped with 03-10"
+                    notes="2018-03-10 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 4, 30),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="Swapped with 04-21"
+                    notes="2018-04-21 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 10, 22),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="Swapped with 10-13"
+                    notes="2018-10-13 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 11, 2),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="Swapped with 11-10"
+                    notes="2018-11-10 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 12, 24),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="Swapped with 12-01"
+                    notes="2018-12-01 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 12, 31),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="Swapped with 12-15"
+                    notes="2018-12-15 munkanap"
                 )]
         if self.year == 2019:
             """
@@ -182,25 +182,25 @@ class hu_HU(Locale):
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 8, 19),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2019-08-10 pihenőnap"
+                    notes="2019-08-10 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 12, 24),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2019-12-07 pihenőnap"
+                    notes="2019-12-07 munkanap"
                 ),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 12, 27),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2019-12-14 pihenőnap"
+                    notes="2019-12-14 munkanap"
                 )]
         if self.year == 2020:
             """
@@ -212,16 +212,16 @@ class hu_HU(Locale):
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 8, 21),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2020-08-29 pihenőnap"),
+                    notes="2020-08-29 munkanap"),
                 Holiday(
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 12, 24),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2020-12-12 pihenőnap"
+                    notes="2020-12-12 munkanap"
                 )]
         if self.year == 2021:
             """
@@ -232,9 +232,9 @@ class hu_HU(Locale):
                     locale=self.locale,
                     region="",
                     date=SmartDayArrow(self.year, 12, 24),
-                    description="Munkaszüneti Nap",
+                    description="Munkaszüneti nap",
                     flags="NF",
-                    notes="2021-12-11 pihenőnap"
+                    notes="2021-12-11 munkanap"
                 )]
         if self.year == 2022:
             """

--- a/holidata/holidays/hu-HU.py
+++ b/holidata/holidays/hu-HU.py
@@ -58,6 +58,7 @@ class hu_HU(Locale):
         2019:  6/2018. (VIII. 23.) PM  rendelet a 2019. évi munkaszüneti napok körüli munkarendről
         2020:  7/2019. (VI.   25.) PM  rendelet a 2020. évi munkaszüneti napok körüli munkarendről
         2021: 14/2020. (V.    13.) ITM rendelet a 2021. évi munkaszüneti napok körüli munkarendről
+        2022: 23/2021. (VI.    1.) ITM rendelet a 2022. évi munkaszüneti napok körüli munkarendről
         """
         if self.year == 2015:
             """
@@ -234,6 +235,27 @@ class hu_HU(Locale):
                     description="Munkaszüneti Nap",
                     flags="NF",
                     notes="2021-12-11 pihenőnap"
+                )]
+        if self.year == 2022:
+            """
+            03-14, swapped with 03-26
+            10-31, swapped with 10-15
+            """
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 3, 14),
+                    description="Munkaszüneti nap",
+                    flags="NF",
+                    notes="2022-03-26 munkanap"),
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=SmartDayArrow(self.year, 10, 31),
+                    description="Munkaszüneti nap",
+                    flags="NF",
+                    notes="2022-10-15 munkanap"
                 )]
 
         return []

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2015] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2015] 1.py
@@ -9,9 +9,9 @@
     },
     {
         'date': '2015-01-02',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2015-01-10 pihenőnap',
+        'notes': '2015-01-10 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -73,9 +73,9 @@
     },
     {
         'date': '2015-08-21',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2015-08-08 pihenőnap',
+        'notes': '2015-08-08 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -97,9 +97,9 @@
     },
     {
         'date': '2015-12-24',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2015-12-12 pihenőnap',
+        'notes': '2015-12-12 munkanap',
         'region': '',
         'type': 'NF'
     },

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2016] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2016] 1.py
@@ -9,9 +9,9 @@
     },
     {
         'date': '2016-03-14',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2016-03-05 pihenőnap',
+        'notes': '2016-03-05 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -81,9 +81,9 @@
     },
     {
         'date': '2016-10-31',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2016-10-15 pihenőnap',
+        'notes': '2016-10-15 munkanap',
         'region': '',
         'type': 'NF'
     },

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2018] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2018] 1.py
@@ -17,9 +17,9 @@
     },
     {
         'date': '2018-03-16',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': 'Swapped with 03-10',
+        'notes': '2018-03-10 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -49,9 +49,9 @@
     },
     {
         'date': '2018-04-30',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': 'Swapped with 04-21',
+        'notes': '2018-04-21 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -89,9 +89,9 @@
     },
     {
         'date': '2018-10-22',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': 'Swapped with 10-13',
+        'notes': '2018-10-13 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -113,17 +113,17 @@
     },
     {
         'date': '2018-11-02',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': 'Swapped with 11-10',
+        'notes': '2018-11-10 munkanap',
         'region': '',
         'type': 'NF'
     },
     {
         'date': '2018-12-24',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': 'Swapped with 12-01',
+        'notes': '2018-12-01 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -145,9 +145,9 @@
     },
     {
         'date': '2018-12-31',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': 'Swapped with 12-15',
+        'notes': '2018-12-15 munkanap',
         'region': '',
         'type': 'NF'
     }

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2019] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2019] 1.py
@@ -65,9 +65,9 @@
     },
     {
         'date': '2019-08-19',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2019-08-10 pihenőnap',
+        'notes': '2019-08-10 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -97,9 +97,9 @@
     },
     {
         'date': '2019-12-24',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2019-12-07 pihenőnap',
+        'notes': '2019-12-07 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -121,9 +121,9 @@
     },
     {
         'date': '2019-12-27',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2019-12-14 pihenőnap',
+        'notes': '2019-12-14 munkanap',
         'region': '',
         'type': 'NF'
     }

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2020] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2020] 1.py
@@ -73,9 +73,9 @@
     },
     {
         'date': '2020-08-21',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2020-08-29 pihenőnap',
+        'notes': '2020-08-29 munkanap',
         'region': '',
         'type': 'NF'
     },
@@ -97,9 +97,9 @@
     },
     {
         'date': '2020-12-24',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2020-12-12 pihenőnap',
+        'notes': '2020-12-12 munkanap',
         'region': '',
         'type': 'NF'
     },

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2021] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2021] 1.py
@@ -89,9 +89,9 @@
     },
     {
         'date': '2021-12-24',
-        'description': 'Munkaszüneti Nap',
+        'description': 'Munkaszüneti nap',
         'locale': 'hu-HU',
-        'notes': '2021-12-11 pihenőnap',
+        'notes': '2021-12-11 munkanap',
         'region': '',
         'type': 'NF'
     },

--- a/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2022] 1.py
+++ b/tests/snapshots/snap_test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu_HU-2022] 1.py
@@ -8,6 +8,14 @@
         'type': 'NF'
     },
     {
+        'date': '2022-03-14',
+        'description': 'Munkaszüneti nap',
+        'locale': 'hu-HU',
+        'notes': '2022-03-26 munkanap',
+        'region': '',
+        'type': 'NF'
+    },
+    {
         'date': '2022-03-15',
         'description': 'Az 1848-as forradalom ünnepe',
         'locale': 'hu-HU',
@@ -76,6 +84,14 @@
         'description': 'Az 1956-os forradalom ünnepe',
         'locale': 'hu-HU',
         'notes': '',
+        'region': '',
+        'type': 'NF'
+    },
+    {
+        'date': '2022-10-31',
+        'description': 'Munkaszüneti nap',
+        'locale': 'hu-HU',
+        'notes': '2022-10-15 munkanap',
         'region': '',
         'type': 'NF'
     },


### PR DESCRIPTION
This adds the non-working days as specified by [*23/2021. (VI. 1.) ITM rendelet a 2022. évi munkaszüneti napok körüli munkarendről*](https://magyarkozlony.hu/dokumentumok/099a8b242a813150dad707d2f24e0916ed100603/megtekintes) (*ITM decree on the work schedule around the 2022 public holidays*)