### PR TITLE
Add locale en-AU

### DIFF
--- a/holidata/holidays/__init__.py
+++ b/holidata/holidays/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "de-CH",
     "de-DE",
     "el-GR",
+    "en-AU",
     "en-CA",
     "en-GB",
     "en-NZ",

--- a/holidata/holidays/en-AU.py
+++ b/holidata/holidays/en-AU.py
@@ -1,0 +1,152 @@
+# coding=utf-8
+from dateutil.easter import EASTER_WESTERN
+
+from holidata.utils import SmartDayArrow
+from .holidays import Holiday, Locale
+
+
+class en_AU(Locale):
+    """
+    01-01: [NF] New Year's Day
+    01-26: [NF] Australia Day
+    04-25: [NF] Anzac Day
+    12-25: [NRF] Christmas Day
+    12-26: [NF] Boxing Day
+    2 days before Easter: [NRV] Good Friday
+    1 day before Easter: [ACT,NT,NSW,QLD,SA,VIC] [RV] Easter Saturday
+    1 day after Easter: [NRV] Easter Monday
+    2 days after Easter: [TAS] [RV] Easter Tuesday
+    1. monday in march: [WA] [V] Labour Day
+    2. monday in march: [ACT] [V] Canberra Day
+    2. monday in march: [SA] [V] Adelaide Cup Day
+    2. monday in march: [TAS] [V] Eight Hours Day
+    2. monday in march: [VIC] [V] Labour Day
+    1. monday in may: [NT] [V] May Day
+    1. monday in may: [QLD] [V] Labour Day
+    1. monday in june: [WA] [V] Western Australia Day
+    2. monday in june: [ACT,NT,NSW,SA,TAS,VIC] [V] Queen's Birthday
+    1. monday in august: [NT] [V] Picnic Day
+    1. monday in october: [ACT,NSW,SA] [V] Labour Day
+    1. monday in october: [QLD] [V] Queen's Birthday
+    1. tuesday in november: [VIC] [V] Melbourne Cup
+    """
+
+    locale = "en-AU"
+    easter_type = EASTER_WESTERN
+
+    def holiday_new_years_day_observed(self):
+        date = SmartDayArrow(self.year, 1, 1)
+
+        if date.weekday() in ["saturday", "sunday"]:
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=date.shift_to_weekday("monday", including=True),
+                    description="New Year's Day (observed)",
+                    flags="NV",
+                    notes="",
+                )
+            ]
+        return []
+
+    def holiday_australia_day_observed(self):
+        date = SmartDayArrow(self.year, 1, 26)
+
+        if date.weekday() in ["saturday", "sunday"]:
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=date.shift_to_weekday("monday", including=True),
+                    description="Australia Day (observed)",
+                    flags="NV",
+                    notes="",
+                )
+            ]
+        return []
+
+    def holiday_anzac_day_observed(self):
+        date = SmartDayArrow(self.year, 4, 25)
+
+        if date.weekday() in ["saturday", "sunday"]:
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region=region,
+                    date=date.shift_to_weekday("monday", including=True),
+                    description="Anzac Day (observed)",
+                    flags="V",
+                    notes="",
+                )
+                for region in ["ACT", "NT", "QLD", "SA"]
+            ]
+        return []
+
+    def holiday_reconciliation_day(self):
+        return [
+            Holiday(
+                locale=self.locale,
+                region="ACT",
+                date=SmartDayArrow(self.year, 5, 27).shift_to_weekday(
+                    "monday", order=1, reverse=False, including=True
+                ),
+                description="Reconciliation Day",
+                flags="V",
+                notes="",
+            )
+        ]
+
+    def holiday_christmas_day_observed(self):
+        date = SmartDayArrow(self.year, 12, 25)
+
+        if date.weekday() == "saturday":
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=date.shift_to_weekday("monday", including=True),
+                    description="Christmas Day (observed)",
+                    flags="NV",
+                    notes="",
+                )
+            ]
+        elif date.weekday() == "sunday":
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=date.shift_to_weekday("tuesday", including=True),
+                    description="Christmas Day (observed)",
+                    flags="NV",
+                    notes="",
+                )
+            ]
+        return []
+
+    def holiday_boxing_day_observed(self):
+        date = SmartDayArrow(self.year, 12, 26)
+
+        if date.weekday() == "saturday":
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=date.shift_to_weekday("monday", including=True),
+                    description="Boxing Day (observed)",
+                    flags="NV",
+                    notes="",
+                )
+            ]
+        elif date.weekday() == "sunday":
+            return [
+                Holiday(
+                    locale=self.locale,
+                    region="",
+                    date=date.shift_to_weekday("tuesday", including=True),
+                    description="Boxing Day (observed)",
+                    flags="NV",
+                    notes="",
+                )
+            ]
+        return []


### PR DESCRIPTION
This adds the holidays for locale `en-AU` (addressing #69) according to relevant state and territory laws:

- Australian Capital Territory [*Holidays Act 1958*](https://legislation.act.gov.au/a/1958-19/)
- New South Wales [*Public Holidays Act 2010*](https://legislation.nsw.gov.au/view/html/inforce/current/act-2010-115)
- Northern Territory [*Public Holidays Act 1981*](https://legislation.nt.gov.au/Search/~/link.aspx?_id=4A14D9136E204F37971A72328969F774&amp;_z=z)
- Queensland [*Holidays Act 1983*](https://www.legislation.qld.gov.au/view/html/inforce/current/act-1983-018)
- South Australia [*Holidays Act 1910*](https://www.legislation.sa.gov.au/lz?path=/c/a/holidays%20act%201910)
- Tasmania [*Statutory Holidays Act 2000*](https://www.legislation.tas.gov.au/view/whole/html/inforce/current/act-2000-096)
- Western Australia [*Public and Bank Holidays Act 1972*](https://www.legislation.wa.gov.au/legislation/statutes.nsf/main_mrtitle_762_homepage.html)
- Victoria [*Public Holidays Act 1993*](https://www.legislation.vic.gov.au/in-force/acts/public-holidays-act-1993/027)

Outstanding issues that require resolving before this can be merged:

- [ ] Victoria observes a holiday for the [AFL Grand Final](https://en.wikipedia.org/wiki/AFL_Grand_Final), whose date is highly variable, falling on a Friday typically between 25 September and 2 October; a rule such as "last Friday before 2 October" misses some years
- [ ] Western Australia observes Queen's Birthday around a similar time, but the exact date does not follow a rule
- [ ] The Northern Territory declares partial holidays on Christmas Eve and New Year's Eve from 7pm to 12am
- [ ] Several regions declare bank holidays, which are holidays observed only by financial institutions and not the general public

Additional notes:

- Formally all regions observe the birthday or anniversary of the reigning sovereign, which is currently Queen Elizabeth II, so the holiday is colloquially known as the Queen's Birthday. This will likely be renamed should the next sovereign not be a queen.
- Different regions have differing names for Easter Saturday; in the interest of readability, these have been combined under a single holiday.
- I noticed that New South Wales declares regional public holidays (specific wording) in the [*Public Holidays Order 2011*](https://legislation.nsw.gov.au/view/html/inforce/current/sl-2011-0081) affecting specific local government areas. This is probably too fine-grained to include given there are no ISO codes for these regions, but I thought I'd flag it.