### PR TITLE
Removal of Columbus Day as an US Holiday

### DIFF
--- a/src/holidata/holidays/en-US.py
+++ b/src/holidata/holidays/en-US.py
@@ -16,7 +16,6 @@ class en_US(Locale):
     3. monday in April: [MA,ME] [V] Patriots' Day
     1. last monday in May: [NV] Memorial Day
     1. monday in September: [NV] Labor Day
-    2. monday in October: [NV] Columbus Day
     4. thursday in November: [NV] Thanksgiving Day
     4. friday in November: [NV] Day after Thanksgiving
     """


### PR DESCRIPTION
[Issue 89](https://github.com/GothenburgBitFactory/holidata/issues/89)

Is it possible to simply remove Columbus Day as a holiday?
A clear and concise description of what the bug is.

Which locale is affected?
en-US
Which holidays are affected?
Columbus Day
Which years does the bug affect?
2022 and future
Additional context
Most US businesses no longer recognize this day an US official holiday and is now referred to as Indigenous People's Day.