### PR TITLE
Enable holidata to be calculated outside confirmed range

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+-      Enable holidata to be calculated outside confirmed range
+
 2024.8.0
 -      Add support for Python 3.12, replace 'snapshottest' with 'syrupy'
 - #105 Holiday "Mariä Himmelfahrt" missing for region 'BY' in locale 'de-DE'

--- a/src/holidata/holidays/ES/CE.py
+++ b/src/holidata/holidays/ES/CE.py
@@ -95,4 +95,4 @@ class CE(Region):
             2024: SmartDayArrow(year, 6, 17),
         }
 
-        return dates[year]
+        return dates.get(year)

--- a/src/holidata/holidays/ES/ML.py
+++ b/src/holidata/holidays/ES/ML.py
@@ -92,7 +92,7 @@ class ML(Region):
             2020: SmartDayArrow(year, 7, 31),
             2021: SmartDayArrow(year, 7, 21),
         }
-        return dates[year]
+        return dates.get(year)
 
     @staticmethod
     def holiday_aid_al_adha(year):
@@ -101,7 +101,7 @@ class ML(Region):
             2023: SmartDayArrow(year, 6, 29),
             2024: SmartDayArrow(year, 6, 17),
         }
-        return dates[year]
+        return dates.get(year)
 
     @staticmethod
     def day_of_eid_fitr(year):
@@ -109,4 +109,4 @@ class ML(Region):
             2022: SmartDayArrow(year, 5, 3),
             2023: SmartDayArrow(year, 4, 21),
         }
-        return dates[year]
+        return dates.get(year)

--- a/src/holidata/holidays/TR.py
+++ b/src/holidata/holidays/TR.py
@@ -107,7 +107,7 @@ class TR(Country):
             2027: SmartDayArrow(2027, 3,  8),
         }
 
-        return ramazan_bayrami_reference[year]
+        return ramazan_bayrami_reference.get(year)
 
     @staticmethod
     def __kurban_bayrami_reference(year):
@@ -131,4 +131,4 @@ class TR(Country):
             2027: SmartDayArrow(2027,  5, 15),
         }
 
-        return kurban_bayrami_reference[year]
+        return kurban_bayrami_reference.get(year)

--- a/src/holidata/holidays/holidays.py
+++ b/src/holidata/holidays/holidays.py
@@ -144,10 +144,13 @@ class HolidayGenerator(object):
                 return []
 
         for region in self.regions:
+            date = self._create_date(self.date, year)
+            if date is None:
+                continue
             yield Holiday(
                 locale=f"{lang}-{self.country_id}",
                 region=region,
-                date=self._create_date(self.date, year),
+                date=date,
                 description=self.name_dict[lang],
                 flags=self.flags,
                 notes=self.notes,

--- a/tests/test_holidata.py
+++ b/tests/test_holidata.py
@@ -38,3 +38,7 @@ def test_holidata_produces_holidays_for_locale_and_year(snapshot_json, locale, y
     export_data.sort(key=lambda x: (x["date"], x["description"], x["region"]))
 
     assert export_data == snapshot_json
+
+
+def test_holidata_can_produce_holidays_out_of_range(locale):
+    [h.as_dict() for h in locale.get_holidays_of(HOLIDATA_YEAR_MAX)]


### PR DESCRIPTION
Calculating holiday data for years which are not defined in all holidays of all countries is not possible because of either KeyErrors being raised when lookups like `reference_date[year]` fail. Switching to `reference_date.get(year)` avoids the KeyError, but returns `None` in case of missing keys which then will make the conversion to string fail.

So we have to make date functions not raise KeyError and skip holidays with None date so they are not printed out.

With the changes in this PR, automated (preliminary) releases on holidata.net are then possible. The data may be incomplete for some countries and will require further updates (e.g. Spain usually releases its holiday calendar in October), but for countries without yearly changing holidays it may be beneficial to have the holiday data available at an earlier time.