### PR TITLE
Add country AU

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+- #112 Add locale en-AU
+       (thanks to Alex Smith)
+
 2024.8.2
 - #113 Fix emitter output
 

--- a/src/holidata/holidays/AU/ACT.py
+++ b/src/holidata/holidays/AU/ACT.py
@@ -1,0 +1,225 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, first, second, day
+
+
+class ACT(Region):
+    def __init__(self, country):
+        super().__init__("ACT", country)
+
+        """
+        New Year's Day
+        1 January, and, if that day falls on a Saturday or Sunday, the following Monday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(ACT.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day
+        26 January, or, if that day falls on a Saturday or Sunday, the following Monday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(self.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        """
+        Canberra Day
+        the 2nd Monday in March;
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Canberra Day") \
+            .on(second("monday").of("march")) \
+            .with_flags("V")
+
+        """
+        Good Friday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        the Saturday following Good Friday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Easter Saturday") \
+            .on(day(1).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Sunday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Easter") \
+            .on(country.easter()) \
+            .with_flags("RV")
+
+        """
+        the Monday following Good Friday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        25 April, or, if that day falls on a Sunday, the following Monday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(self.mon_to_sat_on_or_following(month=4, day=25)) \
+            .with_flags("V")
+
+        """
+        Reconciliation Day
+        27 May, or, if that day is not a Monday, the following Monday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Reconciliation Day") \
+            .on(first("monday").after(month=5, day=26, including=True)) \
+            .with_flags("V")
+
+        """
+        Birthday of the Sovereign
+        the 2nd Monday in June
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .until(2022) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2023) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        Bank Holiday
+        the 1st Monday in August
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Bank Holiday") \
+            .on(first("monday").of("august")) \
+            .with_flags("V")
+
+        """
+        Labour Day
+        the 1st Monday in October
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .on(first("monday").of("october")) \
+            .with_flags("V")
+
+        """
+        Christmas Day
+        25 December, and, if that day falls on a Saturday, the following Monday, or if that day falls on a Sunday, the following Tuesday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("monday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(ACT.date_is_saturday(month=12, day=25))
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("tuesday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(ACT.date_is_sunday(month=12, day=25))
+
+        """
+        Boxing Day
+        26 December and, if that day falls on a Saturday, the following Monday, or, if that day falls on a Sunday, the following Tuesday
+        https://www.legislation.act.gov.au/View/a/1958-19/current/html/1958-19.html
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day") \
+            .on(month=12, day=26) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("monday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(ACT.date_is_saturday(month=12, day=26))
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("tuesday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(ACT.date_is_sunday(month=12, day=26))
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_sat_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() == "sunday":
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper

--- a/src/holidata/holidays/AU/NSW.py
+++ b/src/holidata/holidays/AU/NSW.py
@@ -1,0 +1,219 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, day, second, first
+
+
+class NSW(Region):
+    def __init__(self, country):
+        super().__init__("NSW", country)
+
+        """
+        New Year's Day
+        Public holiday on 1 January.
+        When 1 January is a Saturday or Sunday, there is to be an additional public holiday on the following Monday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(NSW.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day
+        Public holiday on 26 January.
+        When 26 January is a Saturday or Sunday, there is to be no public holiday on that day and instead the following Monday is to be a public holiday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(self.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        """
+        Good Friday
+        Public holiday on the Friday publicly observed as Good Friday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Saturday
+        Public holiday on the day after Good Friday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Easter Saturday") \
+            .on(day(1).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Sunday
+        Public holiday on the Sunday following Good Friday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Easter") \
+            .on(country.easter()) \
+            .with_flags("RV")
+
+        """
+        Easter Monday
+        Public holiday on the Monday following Good Friday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        Public holiday on 25 April.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(month=4, day=25) \
+            .with_flags("F")
+
+        """
+        Queen's Birthday
+        Public holiday on the second Monday in June.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .until(2022) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        King's Birthday
+        Public holiday on the second Monday in June.
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2023) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        Labour Day
+        Public holiday on the first Monday in October.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .on(first("monday").of("october")) \
+            .with_flags("V")
+
+        """
+        Christmas Day
+        Public holiday on 25 December.
+        When 25 December is a Saturday, there is to be an additional public holiday on the following Monday.
+        When 25 December is a Sunday, there is to be an additional public holiday on the following Tuesday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("monday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(NSW.date_is_saturday(month=12, day=25))
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("tuesday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(NSW.date_is_sunday(month=12, day=25))
+
+        """
+        Boxing Day
+        Public holiday on 26 December.
+        When 26 December is a Saturday, there is to be an additional public holiday on the following Monday.
+        When 26 December is a Sunday, there is to be an additional public holiday on the following Tuesday.
+        https://legislation.nsw.gov.au/view/html/inforce/2011-12-31/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2012-07-06/act-2010-115
+        https://legislation.nsw.gov.au/view/html/inforce/2023-01-13/act-2010-115
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day") \
+            .on(month=12, day=26) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("monday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(NSW.date_is_saturday(month=12, day=26))
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("tuesday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(NSW.date_is_sunday(month=12, day=26))
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper

--- a/src/holidata/holidays/AU/NT.py
+++ b/src/holidata/holidays/AU/NT.py
@@ -1,0 +1,210 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, day, first, second
+
+
+class NT(Region):
+    def __init__(self, country):
+        super().__init__("NT", country)
+
+        """
+        New Year's Day
+        1 January, and, if that day falls on a Saturday or Sunday, the following Monday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(self.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day
+        26 January, or, if that day falls on a Saturday or a Sunday, the following Monday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(self.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        """
+        Good Friday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        The Saturday following Good Friday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Easter Saturday") \
+            .on(day(1).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        The Sunday following Good Friday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Easter") \
+            .on(country.easter()) \
+            .with_flags("RV")
+
+        """
+        The Monday following Good Friday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        25 April, or, if that day falls on a Sunday, the following Monday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(self.mon_to_sat_on_or_following(month=4, day=25)) \
+            .with_flags("V")
+
+        """
+        May Day
+        The first Monday in May
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("May Day") \
+            .on(first("monday").of("may")) \
+            .with_flags("V")
+
+        """
+        Birthday of the Sovereign
+        The second Monday in June
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2023) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        Picnic Day
+        The first Monday in August
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Picnic Day") \
+            .on(first("monday").of("august")) \
+            .with_flags("V")
+
+        """
+        24 December (Christmas Eve) from 7.00 pm to midnight
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        """
+        Christmas Day
+        25 December, and, if that day falls on a Saturday or Sunday, the following Monday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("monday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_on_weekend(month=12, day=25))
+
+        """
+        Boxing Day
+        26 December and, if that day falls on a Saturday, the following Monday, or, if that day falls on a Sunday or Monday, the following Tuesday
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day") \
+            .on(month=12, day=26) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("monday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_saturday(month=12, day=26))
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("tuesday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_sunday_or_monday(month=12, day=26))
+
+        """
+        New Year's Eve
+        31 December from 7.00 pm to midnight
+        https://legislation.nt.gov.au/Legislation/PUBLIC-HOLIDAYS-ACT-1981
+        """
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday_or_monday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["sunday", "monday"]
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_sat_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() == "sunday":
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper

--- a/src/holidata/holidays/AU/QLD.py
+++ b/src/holidata/holidays/AU/QLD.py
@@ -1,0 +1,297 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, day, first, second
+
+
+class QLD(Region):
+    def __init__(self, country):
+        super().__init__("QLD", country)
+
+        """
+        New Year's Day
+        Public holiday on 1 January.
+        When 1 January is a Saturday or Sunday, there is to be an additional public holiday on the following Monday.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .since(2012) \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(self.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day
+        Public holiday on 26 January.
+        When 26 January is a Saturday or Sunday, there is to be no public holiday on that day and instead the following Monday is to be a public holiday.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(self.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        """
+        Good Friday
+        Public holiday on the Friday publicly observed as Good Friday.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Saturday
+        Public holiday on the day after Good Friday.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Easter Saturday") \
+            .on(day(1).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Sunday
+        Public holiday on the Sunday following Good Friday.
+        https://www.legislation.qld.gov.au/view/html/2017-03-01/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Easter") \
+            .since(2017) \
+            .on(country.easter()) \
+            .with_flags("RV")
+
+        """
+        Easter Monday
+        Public holiday on the Monday following Good Friday.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        Public holiday on 25 April.
+        25 April (Anzac Day) A public holiday is to be observed on—
+        (a) 25 April; or
+        (b) if 25 April is a Sunday—the following Monday.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(self.mon_to_sat_on_or_following(month=4, day=25)) \
+            .with_flags("V")
+
+        """
+        Labour Day
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .until(2011) \
+            .on(month=5, day=1) \
+            .with_flags("F")
+
+        """
+        A public holiday is to be observed on—
+        (a) 1 May; or
+        (b) if 1 May is a day other than a Monday—the following Monday.
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .since(2012) \
+            .until(2012) \
+            .on(self.monday_on_or_following(month=5, day=1)) \
+            .with_flags("V")
+
+        """
+        A public holiday is to be observed on the first Monday in October.
+        https://www.legislation.qld.gov.au/view/html/2012-11-08/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .since(2013) \
+            .until(2015) \
+            .on(first("monday").of("october")) \
+            .with_flags("V")
+
+        """
+        A public holiday is to be observed on the first Monday in May.
+        https://www.legislation.qld.gov.au/view/html/2015-10-22/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .since(2016) \
+            .on(first("monday").of("may")) \
+            .with_flags("V")
+
+        """
+        Birthday of the Sovereign
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .until(2011) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .since(2012) \
+            .until(2012) \
+            .on(first("monday").of("october")) \
+            .with_flags("V")
+
+        """
+        https://www.legislation.qld.gov.au/view/html/2012-11-08/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .since(2013) \
+            .until(2015) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        https://www.legislation.qld.gov.au/view/html/2015-10-22/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .since(2016) \
+            .until(2021) \
+            .on(first("monday").of("october")) \
+            .with_flags("V")
+
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2022) \
+            .on(first("monday").of("october")) \
+            .with_flags("V")
+
+        """
+        Queen's Diamond Jubilee
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Queen's Diamond Jubilee") \
+            .in_years([2012]) \
+            .on(month=6, day=11) \
+            .with_flags("F")
+
+        """
+        National Day of Mourning for Her Majesty The Queen
+        https://www.legislation.qld.gov.au/view/html/2022-09-15/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("National Day of Mourning for Her Majesty The Queen") \
+            .in_years([2022]) \
+            .on(month=9, day=22) \
+            .with_flags("F")
+
+        """
+        Christmas Day
+        Public holiday on 25 December.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        """
+        27 December
+        A public holiday is to be observed on 27 December only if 25 December is a Saturday or Sunday.
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(month=12, day=27) \
+            .with_flags("RF") \
+            .on_condition(self.date_is_on_weekend(month=12, day=25))
+
+        """
+        Boxing Day
+        Public holiday on 26 December.
+        https://www.legislation.qld.gov.au/view/html/2010-12-10/act-1983-018
+        https://www.legislation.qld.gov.au/view/html/2011-12-06/act-1983-018
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day") \
+            .on(month=12, day=26) \
+            .with_flags("RF")
+
+        """
+        28 December 
+        A public holiday is to be observed on 28 December only if 26 December is a Saturday or Sunday.
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(month=12, day=28) \
+            .with_flags("RF") \
+            .on_condition(self.date_is_on_weekend(month=12, day=26))
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def monday_on_or_following(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).shift_to_weekday("monday", including=True)
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_sat_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() == "sunday":
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper

--- a/src/holidata/holidays/AU/SA.py
+++ b/src/holidata/holidays/AU/SA.py
@@ -1,0 +1,213 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, day, second, first
+
+
+class SA(Region):
+    def __init__(self, country):
+        super().__init__("SA", country)
+
+        """
+        1 January.
+        (a) when a day mentioned in Part 2 of Schedule 2 falls on a Saturday, the
+        following Monday will be a public holiday instead of that day and that day
+        and the following Monday will be bank holidays; and
+        (b) when a day mentioned in Part 2 of Schedule 2 falls on a Sunday, that day and
+        the following Monday will be public holidays and bank holidays.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(self.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day
+        26 January.
+        (a) when a day mentioned in Part 2 of Schedule 2 falls on a Saturday, the
+        following Monday will be a public holiday instead of that day and that day
+        and the following Monday will be bank holidays; and
+        (b) when a day mentioned in Part 2 of Schedule 2 falls on a Sunday, that day and
+        the following Monday will be public holidays and bank holidays.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(self.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        """
+        Good Friday.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        The day after Good Friday.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter Saturday") \
+            .on(day(1).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Sunday
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter") \
+            .on(country.easter()) \
+            .with_flags("RV")
+
+        """
+        Easter Monday.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        In addition to the days mentioned in Schedule 2, 25 April will be a public holiday and
+        bank holiday but when that day falls on a Sunday, that day and the following Monday
+        will be public holidays and bank holidays.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(month=4, day=25) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("Anzac Day (observed)") \
+            .on(first("monday").after(month=4, day=25)) \
+            .with_flags("V") \
+            .on_condition(self.date_is_sunday(month=4, day=25))
+
+        """
+        Adelaide Cup Day
+        Proclaimed as a replacement for the third Monday in May.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Adelaide Cup Day") \
+            .on(self.date_as_declared_by_the_holidays_adelaide_cup_proclamation) \
+            .with_flags("V")
+
+        """
+        Birthday of the Sovereign
+        The second Monday in June.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2023) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        National Day of Mourning for Queen Elizabeth II
+        2022-09-22, as proclaimed by the Holidays (National Day of Mourning for Queen Elizabeth II) Proclamation 2022 (Gazette 16.9.2022 p 6013)
+        https://www.legislation.sa.gov.au/__legislation/lz/v/p/2022/holidays%20(national%20day%20of%20mourning%20for%20queen%20elizabeth%20ii)%20proclamation%202022_16.9.2022%20p%206013/16.9.2022%20p%206013.un.pdf
+        """
+        self.define_holiday() \
+            .with_name("National Day of Mourning for Queen Elizabeth II") \
+            .in_years([2022]) \
+            .on(month=9, day=22) \
+            .with_flags("F")
+
+        """
+        Labour Day
+        The first Monday in October.
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .on(first("monday").of("october")) \
+            .with_flags("V")
+
+        """
+        Christmas Day.
+        (a) when a day mentioned in Part 2 of Schedule 2 falls on a Saturday, the
+        following Monday will be a public holiday instead of that day and that day
+        and the following Monday will be bank holidays; and
+        (b) when a day mentioned in Part 2 of Schedule 2 falls on a Sunday, that day and
+        the following Monday will be public holidays and bank holidays. 
+        https://www.legislation.sa.gov.au/__legislation/lz/c/a/holidays%20act%201910/current/1910.1010.auth.pdf
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("monday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_on_weekend(month=12, day=25))
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper
+
+    @staticmethod
+    def date_as_declared_by_the_holidays_adelaide_cup_proclamation(year):
+        substitution_date = {
+            2011: {"month": 3, "day": 14},  # Holidays (Adelaide Cup) Proclamation 2010
+            2012: {"month": 3, "day": 12},  # Holidays (Adelaide Cup) Proclamation 2011
+            2013: {"month": 3, "day": 11},  # Holidays (Adelaide Cup) Proclamation 2012
+            2014: {"month": 3, "day": 10},
+            2015: {"month": 3, "day":  9},
+            2016: {"month": 3, "day": 14},
+            2017: {"month": 3, "day": 13},
+            2018: {"month": 3, "day": 12},
+            2019: {"month": 3, "day": 11},
+            2020: {"month": 3, "day":  9},
+            2021: {"month": 3, "day":  8},
+            2022: {"month": 3, "day": 14},
+            2023: {"month": 3, "day": 13},
+            2024: {"month": 3, "day": 11},  # subject to Proclamation
+            2025: {"month": 3, "day": 10},  # subject to Proclamation
+        }
+
+        return SmartDayArrow(year, **substitution_date.get(year)) if substitution_date.get(year) is not None else None

--- a/src/holidata/holidays/AU/TAS.py
+++ b/src/holidata/holidays/AU/TAS.py
@@ -1,0 +1,174 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, second, day, first
+
+
+class TAS(Region):
+    def __init__(self, country):
+        super().__init__("TAS", country)
+
+        """
+        New Year's Day (1 January), unless that day falls on a Saturday or Sunday, in which case the Monday following New Year's Day
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(self.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day (26 January), unless that day falls on a Saturday or Sunday, in which case the following Monday
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(self.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        self.define_holiday() \
+            .with_name("Royal Hobart Regatta") \
+            .in_regions(["TAS"]) \
+            .on(second("monday").of("february")) \
+            .with_flags("V")
+
+        """
+        the second Monday in March, known as Eight Hours Day or Labour Day
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .on(second("monday").of("march")) \
+            .with_flags("V")
+
+        """
+        Good Friday
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Monday
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        25 April
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(month=4, day=25) \
+            .with_flags("F")
+
+        """
+        Birthday of the Sovereign
+        the second Monday in June
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .until(2022) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2023) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        Christmas Day (25 December); if Christmas Day falls on a Saturday, the Monday following Christmas Day; if Christmas Day falls on a Sunday, the Tuesday following Christmas Day
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("monday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_on_weekend(month=12, day=25))
+
+        """
+        Boxing Day (26 December), unless that day falls on a Saturday or Sunday, in which case – the Monday following Boxing Day, if that day falls on a Saturday; or the Tuesday following Boxing Day, if that day falls on a Sunday.
+        https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day") \
+            .on(month=12, day=26) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("monday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_saturday(month=12, day=26))
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("tuesday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_sunday_or_monday(month=12, day=26))
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday_or_monday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["sunday", "monday"]
+
+        return wrapper
+
+    @staticmethod
+    def monday_on_or_first_monday_following(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).shift_to_weekday("monday", including=True)
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper

--- a/src/holidata/holidays/AU/VIC.py
+++ b/src/holidata/holidays/AU/VIC.py
@@ -1,0 +1,243 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, second, day, first, last
+
+
+class VIC(Region):
+    def __init__(self, country):
+        super().__init__("VIC", country)
+
+        """
+        New Year's Day
+        1 January, and the Monday after 1 January (New Year's Day) when New Year's Day is a Saturday or Sunday
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(self.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day
+        26 January, or the Monday after Australia Day when Australia Day is a Saturday or Sunday
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf        
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(VIC.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        """
+        Labour Day
+        the second Monday in March
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .on(second("monday").of("march")) \
+            .with_flags("V")
+
+        """
+        Good Friday
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        the Saturday before Easter Sunday
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter Saturday") \
+            .on(day(1).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Sunday
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter") \
+            .since(2019) \
+            .on(country.easter()) \
+            .with_flags("RV")
+
+        """
+        Easter Monday
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        25 April
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(month=4, day=25) \
+            .with_flags("F")
+
+        """
+        Birthday of the Sovereign
+        the second Monday in June
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .until(2022) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2023) \
+            .on(second("monday").of("june")) \
+            .with_flags("V")
+
+        """
+        Grand Final Eve
+        the Friday before the Australian Football League Grand Final
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Grand Final Eve") \
+            .since(2019) \
+            .on(VIC.friday_before_afl_grand_final) \
+            .with_flags("V")
+
+        """
+        Melbourne Cup Day
+        the first Tuesday in November
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Melbourne Cup Day") \
+            .on(first("tuesday").of("november")) \
+            .with_flags("V")
+
+        """
+        25 December (Christmas Day) or the Monday after Christmas Day when Christmas Day is a Saturday or the Tuesday after Christmas Day when Christmas Day is a Sunday
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("monday").after(month=12, day=25)) \
+            .with_flags("RF") \
+            .on_condition(self.date_is_saturday(month=12, day=25))
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("tuesday").after(month=12, day=25)) \
+            .with_flags("RF") \
+            .on_condition(self.date_is_sunday(month=12, day=25))
+
+        """
+        26 December (Boxing Day)
+        the Monday after 26 December (Boxing Day) when Boxing Day is a Saturday or the Tuesday after Boxing Day when Boxing Day is a Sunday
+        2009: https://content.legislation.vic.gov.au/sites/default/files/ccbe13db-9862-3b4f-b16c-8f9a552d2dbc_93-119a024.pdf
+        2011: https://content.legislation.vic.gov.au/sites/default/files/68a646e7-a547-39aa-adac-b2d5e4bfa756_93-119aa025%20authorised.pdf
+        2019: https://content.legislation.vic.gov.au/sites/default/files/ad24ad2c-06f2-3ae3-b0ce-1fcd9b5f61a0_93-119aa026%20authorised.pdf
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day") \
+            .on(month=12, day=26) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("monday").after(month=12, day=26)) \
+            .with_flags("RF") \
+            .on_condition(self.date_is_saturday(month=12, day=26))
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("tuesday").after(month=12, day=26)) \
+            .with_flags("RF") \
+            .on_condition(self.date_is_sunday(month=12, day=26))
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def friday_before_afl_grand_final(year):
+        """
+        Usually, the Friday before last Saturday in September
+        """
+        exception = {
+                2011: {"month":  9, "day": 31},  # MCG was occupied by the International Cricket Council (ICC)
+                2015: {"month": 10, "day":  2},  # Due to scheduling of the 2015 Rugby World Cup
+                2016: {"month":  9, "day": 31},
+                2020: {"month": 10, "day": 23},  # Adaption due to the COVID-19 pandemic
+        }
+
+        if year in exception:
+            return SmartDayArrow(year, **exception[year])
+
+        return first("friday").before(last("saturday").of("september"))(year)
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper

--- a/src/holidata/holidays/AU/WA.py
+++ b/src/holidata/holidays/AU/WA.py
@@ -1,0 +1,241 @@
+from holidata.holiday import Region
+from holidata.utils import SmartDayArrow, day, first
+
+
+class WA(Region):
+    def __init__(self, country):
+        super().__init__("WA", country)
+
+        """
+        New Year's Day
+        1st January
+        When New Year's Day falls on a Saturday or Sunday the next following Monday is also a public holiday and bank holiday.
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("New Year's Day") \
+            .on(month=1, day=1) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("New Year's Day (observed)") \
+            .on(first("monday").after(month=1, day=1)) \
+            .with_flags("V") \
+            .on_condition(self.date_is_on_weekend(month=1, day=1))
+
+        """
+        Australia Day
+        26th January or, when that day falls on a Saturday or Sunday, the first Monday following the 26th January
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Australia Day") \
+            .on(self.mon_to_fri_on_or_following(month=1, day=26)) \
+            .with_flags("V")
+
+        """
+        Labour Day
+        Monday on or first Monday following the 1st March
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Labour Day") \
+            .on(self.monday_on_or_first_monday_following(month=5, day=1)) \
+            .with_flags("V")
+
+        """
+        Good Friday
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Good Friday") \
+            .on(day(2).before(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Easter Sunday
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_44571.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter") \
+            .since(2022) \
+            .on(country.easter()) \
+            .with_flags("RV")
+
+        """
+        Easter Monday
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Easter Monday") \
+            .on(day(1).after(country.easter())) \
+            .with_flags("RV")
+
+        """
+        Anzac Day
+        25th April
+        When Anzac Day falls on a Saturday or Sunday the next following Monday is also a public holiday and bank holiday
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Anzac Day") \
+            .on(month=4, day=25) \
+            .with_flags("F")
+
+        self.define_holiday() \
+            .with_name("Anzac Day (supplement)") \
+            .on(first("monday").after(month=4, day=25)) \
+            .with_flags("F") \
+            .on_condition(self.date_is_on_weekend(month=4, day=25))
+
+        """
+        Western Australia Day/Foundation Day
+        Monday on or first Monday following the 1st June
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Western Australia Day") \
+            .on(self.monday_on_or_first_monday_following(month=6, day=1)) \
+            .with_flags("V")
+
+        """
+        Birthday of the Sovereign
+        day to be appointed for each year by proclamation published in the Government Gazette at least 3 weeks before the day so appointed
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Queen's Birthday") \
+            .until(2022) \
+            .on(self.birthday_of_the_sovereign) \
+            .with_flags("V")
+
+        self.define_holiday() \
+            .with_name("King's Birthday") \
+            .since(2023) \
+            .on(self.birthday_of_the_sovereign) \
+            .with_flags("V")
+
+        """
+        National Day of Mourning for Queen Elizabeth II
+        2022-09-22
+        https://www.legislation.wa.gov.au/legislation/prod/gazettestore.nsf/FileURL/gg2022_138.pdf/$FILE/Gg2022_138.pdf?OpenElement
+        """
+        self.define_holiday() \
+            .with_name("National Day of Mourning for Queen Elizabeth II") \
+            .in_years([2022]) \
+            .on(month=9, day=22) \
+            .with_flags("F")
+
+        """
+        Christmas Day
+        25th December
+        When Christmas Day falls on a Saturday or Sunday the next following Monday is also a public holiday and bank holiday
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Christmas Day") \
+            .on(month=12, day=25) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Christmas Day (observed)") \
+            .on(first("monday").after(month=12, day=25)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_on_weekend(month=12, day=25))
+
+        """
+        Boxing Day
+        26th December
+        When Boxing Day falls on a Saturday the next following Monday is also a public holiday and bank holiday
+        When Boxing Day falls on a Sunday or Monday the next following Tuesday is also a public holiday and bank holiday
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf
+        """
+        self.define_holiday() \
+            .with_name("Boxing Day") \
+            .on(month=12, day=26) \
+            .with_flags("RF")
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("monday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_saturday(month=12, day=26))
+
+        self.define_holiday() \
+            .with_name("Boxing Day (observed)") \
+            .on(first("tuesday").after(month=12, day=26)) \
+            .with_flags("RV") \
+            .on_condition(self.date_is_sunday_or_monday(month=12, day=26))
+
+    @staticmethod
+    def date_is_on_weekend(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["saturday", "sunday"]
+
+        return wrapper
+
+    @staticmethod
+    def date_is_saturday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "saturday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() == "sunday"
+
+        return wrapper
+
+    @staticmethod
+    def date_is_sunday_or_monday(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).weekday() in ["sunday", "monday"]
+
+        return wrapper
+
+    @staticmethod
+    def monday_on_or_first_monday_following(month, day):
+        def wrapper(year):
+            return SmartDayArrow(year, month, day).shift_to_weekday("monday", including=True)
+
+        return wrapper
+
+    @staticmethod
+    def mon_to_fri_on_or_following(month, day):
+        def wrapper(year):
+            date = SmartDayArrow(year, month, day)
+
+            if date.weekday() in ["saturday", "sunday"]:
+                date.shift_to_weekday("monday", including=True)
+
+            return date
+
+        return wrapper
+
+    @staticmethod
+    def birthday_of_the_sovereign(year):
+        """
+        Dates proclaimed in the Government Gazettes
+        https://www.legislation.wa.gov.au/legislation/statutes.nsf/gazettes.html
+        """
+        date = {
+            2011: {"month": 10, "day": 28},  # 2010 234-6261
+            2012: {"month": 10, "day":  1},  # 2008 229-5633
+            2013: {"month":  9, "day": 30},  # 2008 229-5633
+            2014: {"month":  9, "day": 29},  # 2012  61-1687
+            2015: {"month":  9, "day": 28},  # 2012  61-1687
+            2016: {"month":  9, "day": 26},  # 2014  74-1595
+            2017: {"month":  9, "day": 25},  # 2014  74-1595
+            2018: {"month":  9, "day": 24},  # 2016  73-1379
+            2019: {"month":  9, "day": 30},  # 2016  73-1379
+            2020: {"month":  9, "day": 28},  # 2018  53-1287
+            2021: {"month":  9, "day": 27},  # 2018  53-1287
+            2022: {"month":  9, "day": 26},  # 2020 151-2919
+            2023: {"month":  9, "day": 25},  # 2020 151-2919
+            2024: {"month":  9, "day": 23},  # 2022  69-3009
+            2025: {"month":  9, "day": 29},  # 2022  69-3009
+        }
+
+        return SmartDayArrow(year, **date.get(year)) if date.get(year) is not None else None

--- a/src/holidata/holidays/AU/__init__.py
+++ b/src/holidata/holidays/AU/__init__.py
@@ -1,0 +1,37 @@
+from dateutil.easter import EASTER_WESTERN
+
+from holidata.holiday import Country
+from holidata.holidays.AU.ACT import ACT
+from holidata.holidays.AU.NSW import NSW
+from holidata.holidays.AU.NT import NT
+from holidata.holidays.AU.QLD import QLD
+from holidata.holidays.AU.SA import SA
+from holidata.holidays.AU.TAS import TAS
+from holidata.holidays.AU.VIC import VIC
+from holidata.holidays.AU.WA import WA
+
+__all__ = [
+    "AU"
+]
+
+
+class AU(Country):
+    id = "AU"
+    languages = ["en"]
+    default_lang = "en"
+    regions = ["ACT", "NSW", "NT", "QLD", "SA", "TAS", "VIC", "WA"]
+    easter_type = EASTER_WESTERN
+
+    def __init__(self):
+        super().__init__()
+
+        self.regions = [
+            ACT(self),
+            NSW(self),
+            NT(self),
+            QLD(self),
+            SA(self),
+            TAS(self),
+            VIC(self),
+            WA(self),
+        ]

--- a/src/holidata/holidays/__init__.py
+++ b/src/holidata/holidays/__init__.py
@@ -1,3 +1,4 @@
+from .AU import *
 from .DE import *
 from .ES import *
 

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2011].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2011].json
@@ -1,0 +1,842 @@
+[
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2011-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2011-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2011-02-14",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2011-03-14",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2011-03-14",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-03-14",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2011-03-14",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-22",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-23",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-23",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-23",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-23",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-23",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-23",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-24",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-24",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-24",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-24",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2011-04-25",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-05-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2011-05-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2011-05-02",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2011-05-30",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-06-06",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2011-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2011-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2011-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2011-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2011-08-01",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-08-01",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2011-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2011-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2011-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2011-10-28",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2011-11-01",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2011-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2011-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2012].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2012].json
@@ -1,0 +1,770 @@
+[
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2012-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2012-02-13",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2012-03-12",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2012-03-12",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-03-12",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2012-03-12",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-06",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-07",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-07",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-07",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-07",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-07",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-07",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-08",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-08",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-08",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-08",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-09",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2012-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2012-05-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2012-05-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2012-05-07",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2012-05-28",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-06-04",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2012-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2012-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2012-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2012-06-11",
+    "description": "Queen's Diamond Jubilee",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2012-08-06",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-08-06",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2012-10-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2012-10-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2012-10-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2012-10-01",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2012-10-01",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2012-11-06",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2012-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2013].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2013].json
@@ -1,0 +1,698 @@
+[
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2013-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2013-02-11",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2013-03-11",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2013-03-11",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2013-03-11",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2013-03-11",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2013-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2013-05-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2013-05-06",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2013-05-27",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2013-06-03",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2013-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2013-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2013-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2013-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2013-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2013-08-05",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2013-08-05",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2013-09-30",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2013-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2013-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2013-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2013-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2013-11-05",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2013-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2014].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2014].json
@@ -1,0 +1,698 @@
+[
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2014-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2014-02-10",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2014-03-10",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2014-03-10",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2014-03-10",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2014-03-10",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-18",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-19",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-19",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-19",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-19",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-19",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-19",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-20",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-20",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-20",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-20",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-21",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2014-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2014-05-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2014-05-05",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2014-05-26",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2014-06-02",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2014-06-09",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2014-06-09",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2014-06-09",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2014-06-09",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2014-06-09",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2014-08-04",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2014-08-04",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2014-09-29",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2014-10-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2014-10-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2014-10-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2014-10-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2014-11-04",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2014-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2015].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2015].json
@@ -1,0 +1,762 @@
+[
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2015-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2015-02-09",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2015-03-09",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2015-03-09",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2015-03-09",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2015-03-09",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-03",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-04",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-04",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-04",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-04",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-04",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-04",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-05",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-05",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-05",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-05",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-06",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2015-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2015-04-27",
+    "description": "Anzac Day (supplement)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2015-05-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2015-05-04",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2015-06-01",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2015-06-01",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2015-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2015-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2015-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2015-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2015-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2015-08-03",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2015-08-03",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2015-09-28",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2015-10-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2015-10-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2015-10-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2015-10-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2015-11-03",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2015-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2015-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2015-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2015-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2016].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2016].json
@@ -1,0 +1,786 @@
+[
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2016-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2016-02-08",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2016-03-14",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2016-03-14",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2016-03-14",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2016-03-14",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-25",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-26",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-26",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-26",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-26",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-26",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-26",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-27",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-27",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-27",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-27",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2016-03-28",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2016-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2016-05-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2016-05-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2016-05-02",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2016-05-30",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2016-06-06",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2016-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2016-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2016-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2016-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2016-08-01",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2016-08-01",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2016-09-26",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2016-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2016-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2016-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2016-10-03",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2016-11-01",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2016-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2016-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2017].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2017].json
@@ -1,0 +1,770 @@
+[
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2017-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2017-02-13",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2017-03-13",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2017-03-13",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-03-13",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2017-03-13",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-14",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-15",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-15",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-15",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-15",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-15",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-15",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-16",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-16",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-16",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-16",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-16",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-17",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2017-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2017-05-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2017-05-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2017-05-01",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2017-05-29",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-06-05",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2017-06-12",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-06-12",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2017-06-12",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2017-06-12",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2017-08-07",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-08-07",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2017-09-25",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2017-10-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2017-10-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2017-10-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2017-10-02",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2017-11-07",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2017-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2018].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2018].json
@@ -1,0 +1,706 @@
+[
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2018-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2018-02-12",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2018-03-12",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2018-03-12",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2018-03-12",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2018-03-12",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-30",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-31",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-31",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-31",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-31",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-31",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2018-03-31",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-01",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-01",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-01",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-01",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-01",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-02",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2018-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2018-05-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2018-05-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2018-05-07",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2018-05-28",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2018-06-04",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2018-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2018-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2018-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2018-06-11",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2018-08-06",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2018-08-06",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2018-09-24",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2018-10-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2018-10-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2018-10-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2018-10-01",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2018-11-06",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2018-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2019].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2019].json
@@ -1,0 +1,722 @@
+[
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2019-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2019-02-11",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2019-03-11",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2019-03-11",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2019-03-11",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2019-03-11",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-19",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-20",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-20",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-20",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-20",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-20",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-20",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-21",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-21",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-21",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-21",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-21",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-21",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-22",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2019-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2019-05-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2019-05-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2019-05-06",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2019-05-27",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2019-06-03",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2019-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2019-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2019-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2019-06-10",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2019-08-05",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2019-08-05",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2019-09-27",
+    "description": "Grand Final Eve",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2019-09-30",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2019-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2019-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2019-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2019-10-07",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2019-11-05",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2019-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2020].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2020].json
@@ -1,0 +1,786 @@
+[
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2020-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2020-02-10",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2020-03-09",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2020-03-09",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2020-03-09",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2020-03-09",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-10",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-11",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-11",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-11",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-11",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-11",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-11",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-12",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-12",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-12",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-12",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-12",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-12",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-13",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2020-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2020-04-27",
+    "description": "Anzac Day (supplement)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2020-05-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2020-05-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2020-05-04",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2020-06-01",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2020-06-01",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2020-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2020-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2020-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2020-06-08",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2020-08-03",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2020-08-03",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2020-09-28",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2020-10-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2020-10-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2020-10-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2020-10-05",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2020-10-23",
+    "description": "Grand Final Eve",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2020-11-03",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2020-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2020-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2020-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2020-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2021].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2021].json
@@ -1,0 +1,858 @@
+[
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2021-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2021-02-08",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2021-03-08",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2021-03-08",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-03-08",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2021-03-08",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-02",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-03",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-03",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-03",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-03",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-03",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-03",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-04",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-04",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-04",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-04",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-04",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-04",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-05",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2021-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2021-04-26",
+    "description": "Anzac Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2021-04-26",
+    "description": "Anzac Day (supplement)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2021-05-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2021-05-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2021-05-03",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2021-05-31",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-06-07",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2021-06-14",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-06-14",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2021-06-14",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2021-06-14",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2021-08-02",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-08-02",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2021-09-24",
+    "description": "Grand Final Eve",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2021-09-27",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2021-10-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-10-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2021-10-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2021-10-04",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2021-11-02",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2021-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2021-12-28",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2022].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2022].json
@@ -1,0 +1,906 @@
+[
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-03",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2022-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2022-02-14",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2022-03-14",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2022-03-14",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-03-14",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2022-03-14",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-15",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-16",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-16",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-16",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-16",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-16",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-16",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-17",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-17",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-17",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-17",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-17",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-17",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-17",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-18",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2022-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2022-05-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2022-05-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2022-05-02",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2022-05-30",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-06-06",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2022-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2022-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2022-06-13",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2022-08-01",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-08-01",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2022-09-22",
+    "description": "National Day of Mourning for Her Majesty The Queen",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2022-09-22",
+    "description": "National Day of Mourning for Queen Elizabeth II",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2022-09-22",
+    "description": "National Day of Mourning for Queen Elizabeth II",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2022-09-23",
+    "description": "Grand Final Eve",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2022-09-26",
+    "description": "Queen's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2022-10-03",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2022-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2022-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2022-10-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2022-11-01",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-26",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-27",
+    "description": "Boxing Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2022-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2022-12-27",
+    "description": "Christmas Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2023].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2023].json
@@ -1,0 +1,810 @@
+[
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-02",
+    "description": "New Year's Day (observed)",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2023-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2023-02-13",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2023-03-13",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2023-03-13",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-03-13",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2023-03-13",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-07",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-08",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-08",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-08",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-08",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-08",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-08",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-09",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-09",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-09",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-09",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-09",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-09",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-09",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-10",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2023-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2023-05-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2023-05-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2023-05-01",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2023-05-29",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-06-05",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2023-06-12",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-06-12",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2023-06-12",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2023-06-12",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2023-06-12",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2023-06-12",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2023-08-07",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-08-07",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2023-09-25",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2023-09-29",
+    "description": "Grand Final Eve",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2023-10-02",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2023-10-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2023-10-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2023-10-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2023-11-07",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2023-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2024].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2024].json
@@ -1,0 +1,746 @@
+[
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-01",
+    "description": "New Year's Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2024-01-26",
+    "description": "Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2024-02-12",
+    "description": "Royal Hobart Regatta",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2024-03-11",
+    "description": "Adelaide Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2024-03-11",
+    "description": "Canberra Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2024-03-11",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2024-03-11",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-29",
+    "description": "Good Friday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-30",
+    "description": "Easter Saturday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2024-03-31",
+    "description": "Easter",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-01",
+    "description": "Easter Monday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RV"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "F"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "F"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "F"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "F"
+  },
+  {
+    "date": "2024-04-25",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "F"
+  },
+  {
+    "date": "2024-05-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2024-05-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2024-05-06",
+    "description": "May Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2024-05-27",
+    "description": "Reconciliation Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2024-06-03",
+    "description": "Western Australia Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2024-06-10",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2024-06-10",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2024-06-10",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2024-06-10",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2024-06-10",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "V"
+  },
+  {
+    "date": "2024-06-10",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2024-08-05",
+    "description": "Bank Holiday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2024-08-05",
+    "description": "Picnic Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2024-09-23",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
+    "date": "2024-09-27",
+    "description": "Grand Final Eve",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2024-10-07",
+    "description": "King's Birthday",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
+  },
+  {
+    "date": "2024-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2024-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "V"
+  },
+  {
+    "date": "2024-10-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "V"
+  },
+  {
+    "date": "2024-11-05",
+    "description": "Melbourne Cup Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "V"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "SA",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-25",
+    "description": "Christmas Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NSW",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "TAS",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "VIC",
+    "type": "RF"
+  },
+  {
+    "date": "2024-12-26",
+    "description": "Boxing Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "RF"
+  }
+]


### PR DESCRIPTION
This re-opens PR https://github.com/GothenburgBitFactory/holidata/pull/84 by @xeals which targeted the now obsolete master branch. 

The PR was adapted to the latest changes in the Holidata API, e.g. implementing `AU` as a submodule, and using the now present DSL for defining holidays instead of docopt.

