### PR TITLE
Fix emitter output

### DIFF
--- a/src/holidata/emitters.py
+++ b/src/holidata/emitters.py
@@ -28,7 +28,7 @@ class JsonEmitter(Emitter):
     def output(self, holidays: List[Holiday]) -> str:
         export_data: List[Dict[str, Any]] = [h.as_dict() for h in holidays]
         export_data.sort(key=lambda x: (x["date"], x["description"], x["region"]))
-        return json.dumps(export_data, ensure_ascii=False, sort_keys=False, indent=None, separators=(",", ":")) + "\n"
+        return "\n".join([json.dumps(h, ensure_ascii=False, sort_keys=False, indent=None, separators=(",", ":")) for h in export_data]) + "\n"
 
 
 class CsvEmitter(Emitter):

--- a/src/holidata/emitters.py
+++ b/src/holidata/emitters.py
@@ -98,7 +98,7 @@ class XmlEmitter(Emitter):
         export_data: List[Dict[str, Any]] = [h.as_dict() for h in holidays]
         export_data.sort(key=lambda x: (x["date"], x["description"], x["region"]))
 
-        output: str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        output: str = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
         output += "<holidays>\n"
 
         for holiday in export_data:


### PR DESCRIPTION
The refactoring in the last release accidentally changed to output of the JSON emitter to a JSON array. This fix switches it back to the JSON line output.
Also a space before the closing `?>` in the XML header was re-introduced to avoid updates to the present XML Holidata on holidata.net.