### PR TITLE
DK: "Store bededag" was abolished in 2023

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 - Upgrade test requirements pytest to 8.3.5 and syrupy to 4.9.0
+- #119 DK: Holiday "Store bededag" was abolished in 2023
 
 2025.1.0
 -      DE: Document legal sources for region 'TH' (Thüringen)

--- a/src/holidata/holidays/DK.py
+++ b/src/holidata/holidays/DK.py
@@ -56,6 +56,7 @@ class DK(Country):
         self.define_holiday() \
             .with_name("Store bededag") \
             .on(day(26).after(self.easter())) \
+            .until(2023) \
             .with_flags("NRV")
 
         self.define_holiday() \

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[da-DK-2024].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[da-DK-2024].json
@@ -40,14 +40,6 @@
     "type": "NRV"
   },
   {
-    "date": "2024-04-26",
-    "description": "Store bededag",
-    "locale": "da-DK",
-    "notes": "",
-    "region": "",
-    "type": "NRV"
-  },
-  {
     "date": "2024-05-09",
     "description": "Kristi himmelfartsdag",
     "locale": "da-DK",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[da-DK-2025].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[da-DK-2025].json
@@ -40,14 +40,6 @@
     "type": "NRV"
   },
   {
-    "date": "2025-05-16",
-    "description": "Store bededag",
-    "locale": "da-DK",
-    "notes": "",
-    "region": "",
-    "type": "NRV"
-  },
-  {
     "date": "2025-05-29",
     "description": "Kristi himmelfartsdag",
     "locale": "da-DK",


### PR DESCRIPTION
The Danish holiday “store bededag" was abolished by royal decree in 2023.

See e.g. https://sdunet.dk/en/nyheder/nyheder_fra_sdu/storebededag.