### PR TITLE
Add Italian holiday 'Festa nazionale di San Francesco d'Assisi, patrono d'Italia'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+- #137 IT: Add holiday 'Festa nazionale di San Francesco d'Assisi, patrono d'Italia'
+       IT: Add holiday 'Santi Apostoli Pietro e Paolo' for the municipality of Rome
+       IT: Add holiday 'Unità nazionale'
+       (thanks to Flavio Cris)
 - #124 Add Python EOL action
 - #123 Convert all countries into modules
 

--- a/src/holidata/holidays/IT/__init__.py
+++ b/src/holidata/holidays/IT/__init__.py
@@ -1,11 +1,21 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day
+from holidata.utils import day, first
 
 __all__ = [
     "IT",
 ]
+
+"""
+sources:
+- LEGGE 27 maggio   1949, n. 260 https://www.gazzettaufficiale.it/eli/gu/1949/05/31/124/sg
+- LEGGE  5 marzo    1977, n.  54 https://www.gazzettaufficiale.it/eli/id/1977/03/07/077U0054/sg 
+- LEGGE 20 novembre 2000, n. 336 https://www.gazzettaufficiale.it/eli/id/2000/11/22/000G0390/sg
+- DECRETO DEL PRESIDENTE DELLA REPUBBLICA 28 dicembre 1985, n. 792
+                                 https://www.gazzettaufficiale.it/eli/id/1985/12/31/085U0792/sg
+- LEGGE  8 ottobre  2025, n. 151 https://www.gazzettaufficiale.it/eli/id/2025/10/10/25G00153/sg
+"""
 
 
 class IT(Country):
@@ -43,14 +53,31 @@ class IT(Country):
             .with_flags("NF")
 
         self.define_holiday() \
+            .with_name("Santi Apostoli Pietro e Paolo") \
+            .on(month=6, day=29) \
+            .with_flags("NRF") \
+            .annotated_with("Solo per il comune di Roma")
+
+        self.define_holiday() \
             .with_name("Assunzione (ferragosto)") \
             .on(month=8, day=15) \
+            .with_flags("NRF")
+
+        self.define_holiday() \
+            .with_name("Festa nazionale di San Francesco d'Assisi, patrono d'Italia") \
+            .since(2026) \
+            .on(month=10, day=4) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Ognissanti") \
             .on(month=11, day=1) \
             .with_flags("NRF")
+
+        self.define_holiday() \
+            .with_name("Unità nazionale") \
+            .on(first("sunday").of("november")) \
+            .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Immacolata concezione") \

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2011].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2011].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2011-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2011-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2011-11-06",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2011-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2012].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2012].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2012-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2012-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2012-11-04",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2012-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2013].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2013].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2013-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2013-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2013-11-03",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2013-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2014].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2014].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2014-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2014-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2014-11-02",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2014-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2015].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2015].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2015-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2015-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2015-11-01",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2015-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2016].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2016].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2016-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2016-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2016-11-06",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2016-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2017].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2017].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2017-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2017-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2017-11-05",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2017-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2018].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2018].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2018-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2018-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2018-11-04",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2018-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2019].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2019].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2019-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2019-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2019-11-03",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2019-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2020].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2020].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2020-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2020-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2020-11-01",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2020-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2021].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2021].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2021-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2021-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2021-11-07",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2021-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2022].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2022].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2022-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2022-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2022-11-06",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2022-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2023].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2023].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2023-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2023-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2023-11-05",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2023-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2024].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2024].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2024-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2024-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2024-11-03",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2024-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2025].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2025].json
@@ -56,6 +56,14 @@
     "type": "NF"
   },
   {
+    "date": "2025-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2025-08-15",
     "description": "Assunzione (ferragosto)",
     "locale": "it-IT",
@@ -70,6 +78,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2025-11-02",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2025-12-08",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2026].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[it-IT-2026].json
@@ -56,8 +56,24 @@
     "type": "NF"
   },
   {
+    "date": "2026-06-29",
+    "description": "Santi Apostoli Pietro e Paolo",
+    "locale": "it-IT",
+    "notes": "Solo per il comune di Roma",
+    "region": "",
+    "type": "NRF"
+  },
+  {
     "date": "2026-08-15",
     "description": "Assunzione (ferragosto)",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NRF"
+  },
+  {
+    "date": "2026-10-04",
+    "description": "Festa nazionale di San Francesco d'Assisi, patrono d'Italia",
     "locale": "it-IT",
     "notes": "",
     "region": "",
@@ -70,6 +86,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2026-11-01",
+    "description": "Unità nazionale",
+    "locale": "it-IT",
+    "notes": "",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2026-12-08",


### PR DESCRIPTION
Adding the new holiday 'Festa nazionale di San Francesco d'Assisi, patrono d'Italia'

Updating the Italian holidays and aligning them with their sources, leading to 
* holiday 'Santi Apostoli Pietro e Paolo' added for the municipality of Rome
* holiday 'Unità nazionale' added (celebrated on the first Sunday of November)

This finishes the work done in #134 
Closes #134 