### PR TITLE
Add non-working days for 2026 in Hungary

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- #139 HU: Add non-working days for 2026
 - #138 ES: Add holidays for 2026
 - #137 IT: Add holiday 'Festa nazionale di San Francesco d'Assisi, patrono d'Italia'
        IT: Add holiday 'Santi Apostoli Pietro e Paolo' for the municipality of Rome

--- a/src/holidata/holidays/HU/__init__.py
+++ b/src/holidata/holidays/HU/__init__.py
@@ -115,6 +115,7 @@ class HU(Country):
         2022: 23/2021. (VI.    1.) ITM rendelet a 2022. évi munkaszüneti napok körüli munkarendről
         2024: 15/2023. (VII.  13.) GFM rendelet a 2024. évi munkaszüneti napok körüli munkarendről
         2025: 11/2024. (IV.    8.) NGM rendelet a 2025. évi munkaszüneti napok körüli munkarendről
+        2026: 10/2025. (IV.   30.) NGM rendelet a 2026. évi munkaszüneti napok körüli munkarendről
         """
         return {
             2015: [
@@ -159,5 +160,10 @@ class HU(Country):
                 ({"month": 5, "day": 2}, "2025-05-17 munkanap"),
                 ({"month": 10, "day": 24}, "2025-10-18 munkanap"),
                 ({"month": 12, "day": 24}, "2025-12-13 munkanap"),
+            ],
+            2026: [
+                ({"month": 1, "day": 2}, "2026-01-10 munkanap"),
+                ({"month": 8, "day": 21}, "2026-08-08 munkanap"),
+                ({"month": 12, "day": 24}, "2026-12-12 munkanap"),
             ]
         }

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu-HU-2026].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[hu-HU-2026].json
@@ -8,6 +8,14 @@
     "type": "NF"
   },
   {
+    "date": "2026-01-02",
+    "description": "Munkaszüneti nap",
+    "locale": "hu-HU",
+    "notes": "2026-01-10 munkanap",
+    "region": "",
+    "type": "NF"
+  },
+  {
     "date": "2026-03-15",
     "description": "Az 1848-as forradalom ünnepe",
     "locale": "hu-HU",
@@ -72,6 +80,14 @@
     "type": "NF"
   },
   {
+    "date": "2026-08-21",
+    "description": "Munkaszüneti nap",
+    "locale": "hu-HU",
+    "notes": "2026-08-08 munkanap",
+    "region": "",
+    "type": "NF"
+  },
+  {
     "date": "2026-10-23",
     "description": "Az 1956-os forradalom ünnepe",
     "locale": "hu-HU",
@@ -86,6 +102,14 @@
     "notes": "",
     "region": "",
     "type": "NRF"
+  },
+  {
+    "date": "2026-12-24",
+    "description": "Munkaszüneti nap",
+    "locale": "hu-HU",
+    "notes": "2026-12-12 munkanap",
+    "region": "",
+    "type": "NF"
   },
   {
     "date": "2026-12-25",


### PR DESCRIPTION
Add public holidays and their substitute work days according to _10/2025. (IV. 30.) NGM rendelet a 2026. évi munkaszüneti napok körüli munkarendről_.