### PR TITLE
Fix date of Labour Day in Western Australia

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- #140 AU: Fix date of Labour Day in Western Australia
 - #139 HU: Add non-working days for 2026
 - #138 ES: Add holidays for 2026
 - #137 IT: Add holiday 'Festa nazionale di San Francesco d'Assisi, patrono d'Italia'

--- a/src/holidata/holidays/AU/WA.py
+++ b/src/holidata/holidays/AU/WA.py
@@ -40,7 +40,7 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(self.monday_on_or_first_monday_following(month=5, day=1)) \
+            .on(self.monday_on_or_first_monday_following(month=3, day=1)) \
             .with_flags("V")
 
         """

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2011].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2011].json
@@ -192,6 +192,14 @@
     "type": "V"
   },
   {
+    "date": "2011-03-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2011-03-14",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -502,14 +510,6 @@
     "notes": "",
     "region": "QLD",
     "type": "F"
-  },
-  {
-    "date": "2011-05-02",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
-    "type": "V"
   },
   {
     "date": "2011-05-02",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2012].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2012].json
@@ -200,6 +200,14 @@
     "type": "V"
   },
   {
+    "date": "2012-03-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2012-03-12",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -509,14 +517,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2012-05-07",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2013].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2013].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2013-03-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2013-03-11",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -438,14 +446,6 @@
     "notes": "",
     "region": "WA",
     "type": "F"
-  },
-  {
-    "date": "2013-05-06",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
-    "type": "V"
   },
   {
     "date": "2013-05-06",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2014].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2014].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2014-03-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2014-03-10",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -438,14 +446,6 @@
     "notes": "",
     "region": "WA",
     "type": "F"
-  },
-  {
-    "date": "2014-05-05",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
-    "type": "V"
   },
   {
     "date": "2014-05-05",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2015].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2015].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2015-03-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2015-03-09",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -446,14 +454,6 @@
     "notes": "",
     "region": "WA",
     "type": "F"
-  },
-  {
-    "date": "2015-05-04",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
-    "type": "V"
   },
   {
     "date": "2015-05-04",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2016].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2016].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2016-03-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2016-03-14",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -445,14 +453,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2016-05-02",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2017].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2017].json
@@ -200,6 +200,14 @@
     "type": "V"
   },
   {
+    "date": "2017-03-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2017-03-13",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -517,14 +525,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2017-05-01",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2018].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2018].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2018-03-05",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2018-03-12",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -453,14 +461,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2018-05-07",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2019].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2019].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2019-03-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2019-03-11",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -461,14 +469,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2019-05-06",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2020].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2020].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2020-03-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2020-03-09",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -469,14 +477,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2020-05-04",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2021].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2021].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2021-03-01",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2021-03-08",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -477,14 +485,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2021-05-03",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2022].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2022].json
@@ -200,6 +200,14 @@
     "type": "V"
   },
   {
+    "date": "2022-03-07",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2022-03-14",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -533,14 +541,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2022-05-02",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2023].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2023].json
@@ -200,6 +200,14 @@
     "type": "V"
   },
   {
+    "date": "2023-03-06",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2023-03-13",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -533,14 +541,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2023-05-01",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2024].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2024].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2024-03-04",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2024-03-11",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -469,14 +477,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2024-05-06",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2025].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2025].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2025-03-03",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2025-03-10",
     "description": "Adelaide Cup Day",
     "locale": "en-AU",
@@ -469,14 +477,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2025-05-05",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2026].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2026].json
@@ -136,6 +136,14 @@
     "type": "V"
   },
   {
+    "date": "2026-03-02",
+    "description": "Labour Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "WA",
+    "type": "V"
+  },
+  {
     "date": "2026-03-09",
     "description": "Canberra Day",
     "locale": "en-AU",
@@ -469,14 +477,6 @@
     "locale": "en-AU",
     "notes": "",
     "region": "QLD",
-    "type": "V"
-  },
-  {
-    "date": "2026-05-04",
-    "description": "Labour Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "WA",
     "type": "V"
   },
   {


### PR DESCRIPTION
According to [legislation](https://www.legislation.wa.gov.au/legislation/statutes.nsf/RedirectURL?OpenAgent&query=mrdoc_19831.pdf), Labour day is celebrated on the 'Monday on or first Monday following the 1st _March_', which is in the 3rd month, not in the 5th.