### PR TITLE
Fix dates for 'Australia Day' and 'Anzac Day'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- #141 AU: Fix dates for 'Australia Day' and 'Anzac Day'
+
 2025.12.0
 -      Upgrade requirement arrow to 1.4.0
 -      Upgrade test requirements pytest to 9.0.2 and syrupy to 5.0.0

--- a/src/holidata/holidays/AU/ACT.py
+++ b/src/holidata/holidays/AU/ACT.py
@@ -206,7 +206,7 @@ class ACT(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 
@@ -218,7 +218,7 @@ class ACT(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() == "sunday":
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/src/holidata/holidays/AU/NSW.py
+++ b/src/holidata/holidays/AU/NSW.py
@@ -212,7 +212,7 @@ class NSW(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/src/holidata/holidays/AU/NT.py
+++ b/src/holidata/holidays/AU/NT.py
@@ -191,7 +191,7 @@ class NT(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 
@@ -203,7 +203,7 @@ class NT(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() == "sunday":
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/src/holidata/holidays/AU/QLD.py
+++ b/src/holidata/holidays/AU/QLD.py
@@ -278,7 +278,7 @@ class QLD(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 
@@ -290,7 +290,7 @@ class QLD(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() == "sunday":
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/src/holidata/holidays/AU/SA.py
+++ b/src/holidata/holidays/AU/SA.py
@@ -184,7 +184,7 @@ class SA(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/src/holidata/holidays/AU/TAS.py
+++ b/src/holidata/holidays/AU/TAS.py
@@ -167,7 +167,7 @@ class TAS(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/src/holidata/holidays/AU/VIC.py
+++ b/src/holidata/holidays/AU/VIC.py
@@ -236,7 +236,7 @@ class VIC(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/src/holidata/holidays/AU/WA.py
+++ b/src/holidata/holidays/AU/WA.py
@@ -208,7 +208,7 @@ class WA(Region):
             date = SmartDayArrow(year, month, day)
 
             if date.weekday() in ["saturday", "sunday"]:
-                date.shift_to_weekday("monday", including=True)
+                return date.shift_to_weekday("monday", including=True)
 
             return date
 

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2013].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2013].json
@@ -64,7 +64,7 @@
     "type": "F"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -72,7 +72,7 @@
     "type": "V"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -80,7 +80,7 @@
     "type": "V"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -88,7 +88,7 @@
     "type": "V"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -96,7 +96,7 @@
     "type": "V"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -104,7 +104,7 @@
     "type": "V"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -112,7 +112,7 @@
     "type": "V"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -120,7 +120,7 @@
     "type": "V"
   },
   {
-    "date": "2013-01-26",
+    "date": "2013-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2014].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2014].json
@@ -64,7 +64,7 @@
     "type": "F"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -72,7 +72,7 @@
     "type": "V"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -80,7 +80,7 @@
     "type": "V"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -88,7 +88,7 @@
     "type": "V"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -96,7 +96,7 @@
     "type": "V"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -104,7 +104,7 @@
     "type": "V"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -112,7 +112,7 @@
     "type": "V"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -120,7 +120,7 @@
     "type": "V"
   },
   {
-    "date": "2014-01-26",
+    "date": "2014-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2019].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2019].json
@@ -64,7 +64,7 @@
     "type": "F"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -72,7 +72,7 @@
     "type": "V"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -80,7 +80,7 @@
     "type": "V"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -88,7 +88,7 @@
     "type": "V"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -96,7 +96,7 @@
     "type": "V"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -104,7 +104,7 @@
     "type": "V"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -112,7 +112,7 @@
     "type": "V"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -120,7 +120,7 @@
     "type": "V"
   },
   {
-    "date": "2019-01-26",
+    "date": "2019-01-28",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2020].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2020].json
@@ -64,7 +64,7 @@
     "type": "F"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -72,7 +72,7 @@
     "type": "V"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -80,7 +80,7 @@
     "type": "V"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -88,7 +88,7 @@
     "type": "V"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -96,7 +96,7 @@
     "type": "V"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -104,7 +104,7 @@
     "type": "V"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -112,7 +112,7 @@
     "type": "V"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -120,7 +120,7 @@
     "type": "V"
   },
   {
-    "date": "2020-01-26",
+    "date": "2020-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2021].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2021].json
@@ -404,32 +404,8 @@
     "description": "Anzac Day",
     "locale": "en-AU",
     "notes": "",
-    "region": "ACT",
-    "type": "V"
-  },
-  {
-    "date": "2021-04-25",
-    "description": "Anzac Day",
-    "locale": "en-AU",
-    "notes": "",
     "region": "NSW",
     "type": "F"
-  },
-  {
-    "date": "2021-04-25",
-    "description": "Anzac Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "NT",
-    "type": "V"
-  },
-  {
-    "date": "2021-04-25",
-    "description": "Anzac Day",
-    "locale": "en-AU",
-    "notes": "",
-    "region": "QLD",
-    "type": "V"
   },
   {
     "date": "2021-04-25",
@@ -462,6 +438,30 @@
     "notes": "",
     "region": "WA",
     "type": "F"
+  },
+  {
+    "date": "2021-04-26",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "ACT",
+    "type": "V"
+  },
+  {
+    "date": "2021-04-26",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "NT",
+    "type": "V"
+  },
+  {
+    "date": "2021-04-26",
+    "description": "Anzac Day",
+    "locale": "en-AU",
+    "notes": "",
+    "region": "QLD",
+    "type": "V"
   },
   {
     "date": "2021-04-26",

--- a/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2025].json
+++ b/tests/__snapshots__/test_holidata/test_holidata_produces_holidays_for_locale_and_year[en-AU-2025].json
@@ -64,7 +64,7 @@
     "type": "F"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -72,7 +72,7 @@
     "type": "V"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -80,7 +80,7 @@
     "type": "V"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -88,7 +88,7 @@
     "type": "V"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -96,7 +96,7 @@
     "type": "V"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -104,7 +104,7 @@
     "type": "V"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -112,7 +112,7 @@
     "type": "V"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",
@@ -120,7 +120,7 @@
     "type": "V"
   },
   {
-    "date": "2025-01-26",
+    "date": "2025-01-27",
     "description": "Australia Day",
     "locale": "en-AU",
     "notes": "",


### PR DESCRIPTION
Both holidays are shifted if they fall on a weekend or Sunday, respectively. However, the date function always returned the original date, not the shifted one.