### PR TITLE
Use single available language of country as default language

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- #146 Use single available language of country as default language
+
 2026.1.1
 - #145 Add how-to guides
 - #144 PL: Add Christmas Eve as holiday

--- a/src/holidata/holiday.py
+++ b/src/holidata/holiday.py
@@ -124,6 +124,8 @@ class HolidayGenerator:
                 notes=self.notes,
             )
 
+        return None
+
 
 class Country(metaclass=PluginMount):
     """
@@ -144,6 +146,7 @@ class Country(metaclass=PluginMount):
         if self.default_lang is not None and self.default_lang not in self.languages:
             raise ValueError(f"Country '{self.__class__.__name__}' does not list language '{self.default_lang}'!")
 
+        self.default_lang = self.languages[0] if self.default_lang is None and len(self.languages) == 1 else self.default_lang
         self.holiday_generators = []
         self.regions = []
 
@@ -157,6 +160,8 @@ class Country(metaclass=PluginMount):
                 f"Language '{lang_id}' is not defined for country '{self.id}'! Choose one of [{', '.join(self.languages)}].")
         elif lang_id is None and self.default_lang:
             lang_id = self.default_lang
+        elif lang_id is None and len(self.languages) == 1:
+            lang_id = self.languages[0]
         elif lang_id is None:
             raise ValueError(
                 f"Country '{self.id}' has no default language specified! Choose one of [{', '.join(self.languages)}].")

--- a/src/holidata/holidays/AT/__init__.py
+++ b/src/holidata/holidays/AT/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class AT(Country):
     id = "AT"
     languages = ["de"]
-    default_lang = "de"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/AU/__init__.py
+++ b/src/holidata/holidays/AU/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
 class AU(Country):
     id = "AU"
     languages = ["en"]
-    default_lang = "en"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/BR/__init__.py
+++ b/src/holidata/holidays/BR/__init__.py
@@ -47,7 +47,6 @@ __all__ = [
 class BR(Country):
     id = "BR"
     languages = ["pt"]
-    default_lang = "pt"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/CH/__init__.py
+++ b/src/holidata/holidays/CH/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class CH(Country):
     id = "CH"
     languages = ["de"]
-    default_lang = "de"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/CO/__init__.py
+++ b/src/holidata/holidays/CO/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class CO(Country):
     id = "CO"
     languages = ["es"]
-    default_lang = "es"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/CZ/__init__.py
+++ b/src/holidata/holidays/CZ/__init__.py
@@ -19,7 +19,6 @@ source: https://www.zakonyprolidi.cz/cs/2000-245, §1 and §2.
 class CZ(Country):
     id = "CZ"
     languages = ["cs"]
-    default_lang = "cs"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/DE/__init__.py
+++ b/src/holidata/holidays/DE/__init__.py
@@ -27,7 +27,6 @@ __all__ = [
 class DE(Country):
     id = "DE"
     languages = ["de"]
-    default_lang = "de"
     easter_type = EASTER_WESTERN
 
     """

--- a/src/holidata/holidays/DK/__init__.py
+++ b/src/holidata/holidays/DK/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class DK(Country):
     id = "DK"
     languages = ["da"]
-    default_lang = "da"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/EE/__init__.py
+++ b/src/holidata/holidays/EE/__init__.py
@@ -16,7 +16,6 @@ https://www.riigiteataja.ee/akt/109032011007 (Public Holidays and Days of Nation
 class EE(Country):
     id = "EE"
     languages = ["et"]
-    default_lang = "et"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/ES/__init__.py
+++ b/src/holidata/holidays/ES/__init__.py
@@ -64,7 +64,6 @@ Also those sites for some information
 class ES(Country):
     id = "ES"
     languages = ["es"]
-    default_lang = "es"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/FR/__init__.py
+++ b/src/holidata/holidays/FR/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class FR(Country):
     id = "FR"
     languages = ["fr"]
-    default_lang = "fr"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/GB/__init__.py
+++ b/src/holidata/holidays/GB/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class GB(Country):
     id = "GB"
     languages = ["en"]
-    default_lang = "en"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/GR/__init__.py
+++ b/src/holidata/holidays/GR/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class GR(Country):
     id = "GR"
     languages = ["el"]
-    default_lang = "el"
     easter_type = EASTER_ORTHODOX
 
     def __init__(self):

--- a/src/holidata/holidays/HR/__init__.py
+++ b/src/holidata/holidays/HR/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class HR(Country):
     id = "HR"
     languages = ["hr"]
-    default_lang = "hr"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/HU/__init__.py
+++ b/src/holidata/holidays/HU/__init__.py
@@ -19,7 +19,6 @@ sources:
 class HU(Country):
     id = "HU"
     languages = ["hu"]
-    default_lang = "hu"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/IS/__init__.py
+++ b/src/holidata/holidays/IS/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class IS(Country):
     id = "IS"
     languages = ["is"]
-    default_lang = "is"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/IT/__init__.py
+++ b/src/holidata/holidays/IT/__init__.py
@@ -21,7 +21,6 @@ sources:
 class IT(Country):
     id = "IT"
     languages = ["it"]
-    default_lang = "it"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/NL/__init__.py
+++ b/src/holidata/holidays/NL/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class NL(Country):
     id = "NL"
     languages = ["nl"]
-    default_lang = "nl"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/NO/__init__.py
+++ b/src/holidata/holidays/NO/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class NO(Country):
     id = "NO"
     languages = ["nb"]
-    default_lang = "nb"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/NZ/__init__.py
+++ b/src/holidata/holidays/NZ/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class NZ(Country):
     id = "NZ"
     languages = ["en"]
-    default_lang = "en"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/PL/__init__.py
+++ b/src/holidata/holidays/PL/__init__.py
@@ -16,7 +16,6 @@ source2: https://isap.sejm.gov.pl/isap.nsf/download.xsp/WDU20240001965/T/D202419
 class PL(Country):
     id = "PL"
     languages = ["pl"]
-    default_lang = "pl"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/PT/__init__.py
+++ b/src/holidata/holidays/PT/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class PT(Country):
     id = "PT"
     languages = ["pt"]
-    default_lang = "pt"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/RU/__init__.py
+++ b/src/holidata/holidays/RU/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class RU(Country):
     id = "RU"
     languages = ["ru"]
-    default_lang = "ru"
     easter_type = EASTER_ORTHODOX
 
     def __init__(self):

--- a/src/holidata/holidays/SE/__init__.py
+++ b/src/holidata/holidays/SE/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class SE(Country):
     id = "SE"
     languages = ["sv"]
-    default_lang = "sv"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/SG/__init__.py
+++ b/src/holidata/holidays/SG/__init__.py
@@ -21,8 +21,6 @@ Legal sources:
 class SG(Country):
     id = "SG"
     languages = ["en"]
-    default_lang = "en"
-    regions = []
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/SI/__init__.py
+++ b/src/holidata/holidays/SI/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class SI(Country):
     id = "SI"
     languages = ["sl"]
-    default_lang = "sl"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/SK/__init__.py
+++ b/src/holidata/holidays/SK/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class SK(Country):
     id = "SK"
     languages = ["sk"]
-    default_lang = "sk"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/TR/__init__.py
+++ b/src/holidata/holidays/TR/__init__.py
@@ -17,7 +17,6 @@ dates for holidays 'Ramazan Bayramı' and 'Kurban Bayramı': https://vakithesapl
 class TR(Country):
     id = "TR"
     languages = ["tr"]
-    default_lang = "tr"
     easter_type = EASTER_WESTERN
 
     def __init__(self):

--- a/src/holidata/holidays/ZA/__init__.py
+++ b/src/holidata/holidays/ZA/__init__.py
@@ -11,7 +11,6 @@ __all__ = [
 class ZA(Country):
     id = "ZA"
     languages = ["en"]
-    default_lang = "en"
     easter_type = EASTER_WESTERN
 
     def __init__(self):


### PR DESCRIPTION
This way, one does not have to define a default language for a country with only a single available language. Remove explicit setting of default language for single-language countries