### PR TITLE
Use enums for month and weekday names

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- #147 Use enums for month and weekday names
 - #146 Use single available language of country as default language
 
 2026.1.1

--- a/docs/how-tos/define-holidays.md
+++ b/docs/how-tos/define-holidays.md
@@ -36,21 +36,22 @@ The Holidata library provides a set of _date functions_ to handle the different 
 The `date` function can be used for holidays taking place on a fixed date (_n-th day of a month_), e.g.:
 
 ```python
-date(month=1, day=1)    # January 1st
-date(month=12, day=25)  # December 25th
+date(Month.JANUARY, 1)    # January 1st
+date(Month.DECEMBER, 25)  # December 25th
 ```
 
 ### Weekday Occurrences
 
 For holidays which take place on a certain weekday of a month, there are the functions `first`, `second`, `third`, `fourth`, and `last` to handle those cases, e.g.:
+
 ```python
 # n-th occurrence of a weekday in a month
-first("monday").of("may")
-second("tuesday").of("june")
-third("wednesday").of("july")
-fourth("thursday").of("august")
+first(Weekday.MONDAY).of(Month.MAY)
+second(Weekday.TUESDAY).of(Month.JUNE)
+third(Weekday.WEDNESDAY).of(Month.JULY)
+fourth(Weekday.THURSDAY).of(Month.AUGUST)
 
-last("friday").of("september")
+last(Weekday.FRIDAY).of(Month.SEPTEMBER)
 ```
 
 ### Easter-Based Dates
@@ -82,14 +83,14 @@ day(2).before(<date_function>)  # 2 days before
 day(1).after(<date_function>)   # 1 day after 
 
 # Weekday before/after a date
-first("monday").before(<date_function>)
-second("tuesday").after(<date_function>)
+first(Weekday.MONDAY).before(<date_function>)
+second(Weekday.TUESDAY).after(<date_function>)
 ```
 
 Those calls can be nested. An example for this would be the German holiday _Buß- und Bettag_ which takes place on the 11th day before the first Advent Sunday, which is the fourth sunday before Christmas:
 
 ```python
-day(11).before(fourth("sunday").before(date(month=12, day=25)))
+day(11).before(fourth(Weekday.SUNDAY).before(date(Month.DECEMBER, 25)))
 ```
 
 ### Custom Date Functions

--- a/src/holidata/holiday.py
+++ b/src/holidata/holiday.py
@@ -26,7 +26,7 @@ class Holiday:
             "date": self.date.strftime("%Y-%m-%d"),
             "description": self.description,
             "type": self.flags,
-            "notes": self.notes
+            "notes": self.notes,
         }
 
 

--- a/src/holidata/holidays/AT/__init__.py
+++ b/src/holidata/holidays/AT/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "AT",
@@ -18,93 +18,93 @@ class AT(Country):
 
         self.define_holiday() \
             .with_name("Neujahr") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Heilige drei Könige") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Josef") \
             .in_regions(["2", "6", "7", "8"]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Staatsfeiertag") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Florian") \
             .in_regions(["4"]) \
-            .on(date(month=5, day=4)) \
+            .on(date(Month.MAY, 4)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Mariä Himmelfahrt") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Rupert") \
             .in_regions(["5"]) \
-            .on(date(month=9, day=24)) \
+            .on(date(Month.SEPTEMBER, 24)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Tag der Volksabstimmung") \
             .in_regions(["2"]) \
-            .on(date(month=10, day=10)) \
+            .on(date(Month.OCTOBER, 10)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Nationalfeiertag") \
-            .on(date(month=10, day=26)) \
+            .on(date(Month.OCTOBER, 26)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Allerheiligen") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Martin") \
             .in_regions(["1"]) \
-            .on(date(month=11, day=11)) \
+            .on(date(Month.NOVEMBER, 11)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Leopold") \
             .in_regions(["9", "3"]) \
-            .on(date(month=11, day=15)) \
+            .on(date(Month.NOVEMBER, 15)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Mariä Empfängnis") \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Heiliger Abend") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Christtag") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Stefanitag") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Silvester") \
-            .on(date(month=12, day=31)) \
+            .on(date(Month.DECEMBER, 31)) \
             .with_flags("NF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/AU/ACT.py
+++ b/src/holidata/holidays/AU/ACT.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import first, second, day, date
+from holidata.utils import first, second, day, date, Weekday, Month
 
 
 class ACT(Region):
@@ -13,14 +13,14 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day
@@ -29,14 +29,14 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         """
@@ -46,7 +46,7 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Canberra Day") \
-            .on(second("monday").of("march")) \
+            .on(second(Weekday.MONDAY).of(Month.MARCH)) \
             .with_flags("V")
 
         """
@@ -92,14 +92,14 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
-            .on_condition(date(month=4, day=25).is_not_a("sunday")) \
+            .on(date(Month.APRIL, 25)) \
+            .on_condition(date(Month.APRIL, 25).is_not_a(Weekday.SUNDAY)) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(first("monday").after(date(month=4, day=25))) \
-            .on_condition(date(month=4, day=25).is_a("sunday")) \
+            .on(first(Weekday.MONDAY).after(date(Month.APRIL, 25))) \
+            .on_condition(date(Month.APRIL, 25).is_a(Weekday.SUNDAY)) \
             .with_flags("V")
 
         """
@@ -109,7 +109,7 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Reconciliation Day") \
-            .on(first("monday").after(date(month=5, day=26), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.MAY, 26), including=True)) \
             .with_flags("V")
 
         """
@@ -120,13 +120,13 @@ class ACT(Region):
         self.define_holiday() \
             .with_name("Queen's Birthday") \
             .until(2022) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("King's Birthday") \
             .since(2023) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -136,7 +136,7 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Bank Holiday") \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("V")
 
         """
@@ -146,7 +146,7 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(first("monday").of("october")) \
+            .on(first(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         """
@@ -156,20 +156,20 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=25))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SUNDAY))
 
         """
         Boxing Day
@@ -178,17 +178,17 @@ class ACT(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SUNDAY))

--- a/src/holidata/holidays/AU/NSW.py
+++ b/src/holidata/holidays/AU/NSW.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, second, first, date
+from holidata.utils import day, second, first, date, Weekday, Month
 
 
 class NSW(Region):
@@ -16,14 +16,14 @@ class NSW(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day
@@ -35,14 +35,14 @@ class NSW(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         """
@@ -102,7 +102,7 @@ class NSW(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("F")
 
         """
@@ -114,7 +114,7 @@ class NSW(Region):
         self.define_holiday() \
             .with_name("Queen's Birthday") \
             .until(2022) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -125,7 +125,7 @@ class NSW(Region):
         self.define_holiday() \
             .with_name("King's Birthday") \
             .since(2023) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -137,7 +137,7 @@ class NSW(Region):
         """
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(first("monday").of("october")) \
+            .on(first(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         """
@@ -151,20 +151,20 @@ class NSW(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=25))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SUNDAY))
 
         """
         Boxing Day
@@ -177,17 +177,17 @@ class NSW(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SUNDAY))

--- a/src/holidata/holidays/AU/NT.py
+++ b/src/holidata/holidays/AU/NT.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, first, second, date
+from holidata.utils import day, first, second, date, Weekday, Month
 
 
 class NT(Region):
@@ -13,14 +13,14 @@ class NT(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day
@@ -29,14 +29,14 @@ class NT(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         """
@@ -82,14 +82,14 @@ class NT(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
-            .on_condition(date(month=4, day=25).is_not_a("sunday")) \
+            .on(date(Month.APRIL, 25)) \
+            .on_condition(date(Month.APRIL, 25).is_not_a(Weekday.SUNDAY)) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(first("monday").after(date(month=4, day=25))) \
-            .on_condition(date(month=4, day=25).is_a("sunday")) \
+            .on(first(Weekday.MONDAY).after(date(Month.APRIL, 25))) \
+            .on_condition(date(Month.APRIL, 25).is_a(Weekday.SUNDAY)) \
             .with_flags("V")
 
         """
@@ -99,7 +99,7 @@ class NT(Region):
         """
         self.define_holiday() \
             .with_name("May Day") \
-            .on(first("monday").of("may")) \
+            .on(first(Weekday.MONDAY).of(Month.MAY)) \
             .with_flags("V")
 
         """
@@ -110,7 +110,7 @@ class NT(Region):
         self.define_holiday() \
             .with_name("King's Birthday") \
             .since(2023) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -120,7 +120,7 @@ class NT(Region):
         """
         self.define_holiday() \
             .with_name("Picnic Day") \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("V")
 
         """
@@ -134,14 +134,14 @@ class NT(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.DECEMBER, 25).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Boxing Day
@@ -150,20 +150,20 @@ class NT(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_one_of(["sunday", "monday"]))
+            .on_condition(date(Month.DECEMBER, 26).is_one_of([Weekday.SUNDAY, Weekday.MONDAY]))
 
         """
         New Year's Eve

--- a/src/holidata/holidays/AU/QLD.py
+++ b/src/holidata/holidays/AU/QLD.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, first, second, date
+from holidata.utils import day, first, second, date, Weekday, Month
 
 
 class QLD(Region):
@@ -15,15 +15,15 @@ class QLD(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
             .since(2012) \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day
@@ -34,14 +34,14 @@ class QLD(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         """
@@ -96,14 +96,14 @@ class QLD(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
-            .on_condition(date(month=4, day=25).is_not_a("sunday")) \
+            .on(date(Month.APRIL, 25)) \
+            .on_condition(date(Month.APRIL, 25).is_not_a(Weekday.SUNDAY)) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(first("monday").after(date(month=4, day=25))) \
-            .on_condition(date(month=4, day=25).is_a("sunday")) \
+            .on(first(Weekday.MONDAY).after(date(Month.APRIL, 25))) \
+            .on_condition(date(Month.APRIL, 25).is_a(Weekday.SUNDAY)) \
             .with_flags("V")
 
         """
@@ -113,7 +113,7 @@ class QLD(Region):
         self.define_holiday() \
             .with_name("Labour Day") \
             .until(2011) \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("F")
 
         """
@@ -126,7 +126,7 @@ class QLD(Region):
             .with_name("Labour Day") \
             .since(2012) \
             .until(2012) \
-            .on(first("monday").of("may")) \
+            .on(first(Weekday.MONDAY).of(Month.MAY)) \
             .with_flags("V")
 
         """
@@ -137,7 +137,7 @@ class QLD(Region):
             .with_name("Labour Day") \
             .since(2013) \
             .until(2015) \
-            .on(first("monday").of("october")) \
+            .on(first(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         """
@@ -147,7 +147,7 @@ class QLD(Region):
         self.define_holiday() \
             .with_name("Labour Day") \
             .since(2016) \
-            .on(first("monday").of("may")) \
+            .on(first(Weekday.MONDAY).of(Month.MAY)) \
             .with_flags("V")
 
         """
@@ -157,7 +157,7 @@ class QLD(Region):
         self.define_holiday() \
             .with_name("Queen's Birthday") \
             .until(2011) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -167,7 +167,7 @@ class QLD(Region):
             .with_name("Queen's Birthday") \
             .since(2012) \
             .until(2012) \
-            .on(first("monday").of("october")) \
+            .on(first(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         """
@@ -177,7 +177,7 @@ class QLD(Region):
             .with_name("Queen's Birthday") \
             .since(2013) \
             .until(2015) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -187,13 +187,13 @@ class QLD(Region):
             .with_name("Queen's Birthday") \
             .since(2016) \
             .until(2021) \
-            .on(first("monday").of("october")) \
+            .on(first(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("King's Birthday") \
             .since(2022) \
-            .on(first("monday").of("october")) \
+            .on(first(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         """
@@ -203,7 +203,7 @@ class QLD(Region):
         self.define_holiday() \
             .with_name("Queen's Diamond Jubilee") \
             .in_years([2012]) \
-            .on(date(month=6, day=11)) \
+            .on(date(Month.JUNE, 11)) \
             .with_flags("F")
 
         """
@@ -213,7 +213,7 @@ class QLD(Region):
         self.define_holiday() \
             .with_name("National Day of Mourning for Her Majesty The Queen") \
             .in_years([2022]) \
-            .on(date(month=9, day=22)) \
+            .on(date(Month.SEPTEMBER, 22)) \
             .with_flags("F")
 
         """
@@ -224,7 +224,7 @@ class QLD(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         """
@@ -233,9 +233,9 @@ class QLD(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(date(month=12, day=27)) \
+            .on(date(Month.DECEMBER, 27)) \
             .with_flags("RF") \
-            .on_condition(date(month=12, day=25).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.DECEMBER, 25).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Boxing Day
@@ -245,7 +245,7 @@ class QLD(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         """
@@ -254,6 +254,6 @@ class QLD(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(date(month=12, day=28)) \
+            .on(date(Month.DECEMBER, 28)) \
             .with_flags("RF") \
-            .on_condition(date(month=12, day=26).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.DECEMBER, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))

--- a/src/holidata/holidays/AU/SA.py
+++ b/src/holidata/holidays/AU/SA.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, second, first, date
+from holidata.utils import day, second, first, date, Weekday, Month
 
 
 class SA(Region):
@@ -17,14 +17,14 @@ class SA(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day
@@ -38,14 +38,14 @@ class SA(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         """
@@ -93,14 +93,14 @@ class SA(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Anzac Day (observed)") \
-            .on(first("monday").after(date(month=4, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.APRIL, 25))) \
             .with_flags("V") \
-            .on_condition(date(month=4, day=25).is_a("sunday"))
+            .on_condition(date(Month.APRIL, 25).is_a(Weekday.SUNDAY))
 
         """
         Adelaide Cup Day
@@ -120,7 +120,7 @@ class SA(Region):
         self.define_holiday() \
             .with_name("King's Birthday") \
             .since(2023) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -131,7 +131,7 @@ class SA(Region):
         self.define_holiday() \
             .with_name("National Day of Mourning for Queen Elizabeth II") \
             .in_years([2022]) \
-            .on(date(month=9, day=22)) \
+            .on(date(Month.SEPTEMBER, 22)) \
             .with_flags("F")
 
         """
@@ -141,7 +141,7 @@ class SA(Region):
         """
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(first("monday").of("october")) \
+            .on(first(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         """
@@ -155,33 +155,33 @@ class SA(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.DECEMBER, 25).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
     @staticmethod
     def date_as_declared_by_the_holidays_adelaide_cup_proclamation(year):
         dates = {
-            2011: date(month=3, day=14),  # Holidays (Adelaide Cup) Proclamation 2010
-            2012: date(month=3, day=12),  # Holidays (Adelaide Cup) Proclamation 2011
-            2013: date(month=3, day=11),  # Holidays (Adelaide Cup) Proclamation 2012
-            2014: date(month=3, day=10),
-            2015: date(month=3, day=9),
-            2016: date(month=3, day=14),
-            2017: date(month=3, day=13),
-            2018: date(month=3, day=12),
-            2019: date(month=3, day=11),
-            2020: date(month=3, day=9),
-            2021: date(month=3, day=8),
-            2022: date(month=3, day=14),
-            2023: date(month=3, day=13),
-            2024: date(month=3, day=11),  # subject to Proclamation
-            2025: date(month=3, day=10),  # subject to Proclamation
+            2011: date(Month.MARCH, 14),  # Holidays (Adelaide Cup) Proclamation 2010
+            2012: date(Month.MARCH, 12),  # Holidays (Adelaide Cup) Proclamation 2011
+            2013: date(Month.MARCH, 11),  # Holidays (Adelaide Cup) Proclamation 2012
+            2014: date(Month.MARCH, 10),
+            2015: date(Month.MARCH, 9),
+            2016: date(Month.MARCH, 14),
+            2017: date(Month.MARCH, 13),
+            2018: date(Month.MARCH, 12),
+            2019: date(Month.MARCH, 11),
+            2020: date(Month.MARCH, 9),
+            2021: date(Month.MARCH, 8),
+            2022: date(Month.MARCH, 14),
+            2023: date(Month.MARCH, 13),
+            2024: date(Month.MARCH, 11),  # subject to Proclamation
+            2025: date(Month.MARCH, 10),  # subject to Proclamation
         }
 
         return dates.get(year)(year) if year in dates else None

--- a/src/holidata/holidays/AU/TAS.py
+++ b/src/holidata/holidays/AU/TAS.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import second, day, first, date
+from holidata.utils import second, day, first, date, Weekday, Month
 
 
 class TAS(Region):
@@ -12,14 +12,14 @@ class TAS(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day (26 January), unless that day falls on a Saturday or Sunday, in which case the following Monday
@@ -27,20 +27,20 @@ class TAS(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Royal Hobart Regatta") \
             .in_regions(["TAS"]) \
-            .on(second("monday").of("february")) \
+            .on(second(Weekday.MONDAY).of(Month.FEBRUARY)) \
             .with_flags("V")
 
         """
@@ -49,7 +49,7 @@ class TAS(Region):
         """
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(second("monday").of("march")) \
+            .on(second(Weekday.MONDAY).of(Month.MARCH)) \
             .with_flags("V")
 
         """
@@ -77,7 +77,7 @@ class TAS(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("F")
 
         """
@@ -88,13 +88,13 @@ class TAS(Region):
         self.define_holiday() \
             .with_name("Queen's Birthday") \
             .until(2022) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("King's Birthday") \
             .since(2023) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -103,14 +103,14 @@ class TAS(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25), including=False)) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25), including=False)) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.DECEMBER, 25).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Boxing Day (26 December), unless that day falls on a Saturday or Sunday, in which case – the Monday following Boxing Day, if that day falls on a Saturday; or the Tuesday following Boxing Day, if that day falls on a Sunday.
@@ -118,17 +118,17 @@ class TAS(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_one_of(["sunday", "monday"]))
+            .on_condition(date(Month.DECEMBER, 26).is_one_of([Weekday.SUNDAY, Weekday.MONDAY]))

--- a/src/holidata/holidays/AU/VIC.py
+++ b/src/holidata/holidays/AU/VIC.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import second, day, first, last, date
+from holidata.utils import second, day, first, last, date, Weekday, Month
 
 
 class VIC(Region):
@@ -15,14 +15,14 @@ class VIC(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day
@@ -33,14 +33,14 @@ class VIC(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         """
@@ -52,7 +52,7 @@ class VIC(Region):
         """
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(second("monday").of("march")) \
+            .on(second(Weekday.MONDAY).of(Month.MARCH)) \
             .with_flags("V")
 
         """
@@ -107,7 +107,7 @@ class VIC(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("F")
 
         """
@@ -120,13 +120,13 @@ class VIC(Region):
         self.define_holiday() \
             .with_name("Queen's Birthday") \
             .until(2022) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("King's Birthday") \
             .since(2023) \
-            .on(second("monday").of("june")) \
+            .on(second(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -149,7 +149,7 @@ class VIC(Region):
         """
         self.define_holiday() \
             .with_name("Melbourne Cup Day") \
-            .on(first("tuesday").of("november")) \
+            .on(first(Weekday.TUESDAY).of(Month.NOVEMBER)) \
             .with_flags("V")
 
         """
@@ -160,20 +160,20 @@ class VIC(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RF") \
-            .on_condition(date(month=12, day=25).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=25))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RF") \
-            .on_condition(date(month=12, day=25).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SUNDAY))
 
         """
         26 December (Boxing Day)
@@ -184,20 +184,20 @@ class VIC(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RF") \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RF") \
-            .on_condition(date(month=12, day=26).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SUNDAY))
 
     @staticmethod
     def friday_before_afl_grand_final(year):
@@ -205,13 +205,13 @@ class VIC(Region):
         Usually, the Friday before last Saturday in September
         """
         exception = {
-            2011: date(month=9, day=31),  # MCG was occupied by the International Cricket Council (ICC)
-            2015: date(month=10, day=2),  # Due to scheduling of the 2015 Rugby World Cup
-            2016: date(month=9, day=31),
-            2020: date(month=10, day=23),  # Adaption due to the COVID-19 pandemic
+            2011: date(Month.SEPTEMBER, 31),  # MCG was occupied by the International Cricket Council (ICC)
+            2015: date(Month.OCTOBER, 2),     # Due to scheduling of the 2015 Rugby World Cup
+            2016: date(Month.SEPTEMBER, 31),
+            2020: date(Month.OCTOBER, 23),    # Adaption due to the COVID-19 pandemic
         }
 
         if year in exception:
             return exception[year](year)
 
-        return first("friday").before(last("saturday").of("september"))(year)
+        return first(Weekday.FRIDAY).before(last(Weekday.SATURDAY).of(Month.SEPTEMBER))(year)

--- a/src/holidata/holidays/AU/WA.py
+++ b/src/holidata/holidays/AU/WA.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, first, date
+from holidata.utils import day, first, date, Weekday, Month
 
 
 class WA(Region):
@@ -14,14 +14,14 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("V") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Australia Day
@@ -30,14 +30,14 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(date(month=1, day=26)) \
-            .on_condition(date(month=1, day=26).is_none_of(["saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 26)) \
+            .on_condition(date(Month.JANUARY, 26).is_none_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         self.define_holiday() \
             .with_name("Australia Day") \
-            .on(first("monday").after(date(month=1, day=26))) \
-            .on_condition(date(month=1, day=26).is_one_of(["saturday", "sunday"])) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 26))) \
+            .on_condition(date(Month.JANUARY, 26).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("V")
 
         """
@@ -47,7 +47,7 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(first("monday").of("march")) \
+            .on(first(Weekday.MONDAY).of(Month.MARCH)) \
             .with_flags("V")
 
         """
@@ -86,14 +86,14 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("Anzac Day") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Anzac Day (supplement)") \
-            .on(first("monday").after(date(month=4, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.APRIL, 25))) \
             .with_flags("F") \
-            .on_condition(date(month=4, day=25).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.APRIL, 25).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Western Australia Day/Foundation Day
@@ -102,7 +102,7 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("Western Australia Day") \
-            .on(first("monday").of("june")) \
+            .on(first(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("V")
 
         """
@@ -130,7 +130,7 @@ class WA(Region):
         self.define_holiday() \
             .with_name("National Day of Mourning for Queen Elizabeth II") \
             .in_years([2022]) \
-            .on(date(month=9, day=22)) \
+            .on(date(Month.SEPTEMBER, 22)) \
             .with_flags("F")
 
         """
@@ -141,14 +141,14 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=25).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.DECEMBER, 25).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         """
         Boxing Day
@@ -159,20 +159,20 @@ class WA(Region):
         """
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("RV") \
-            .on_condition(date(month=12, day=26).is_one_of(["sunday", "monday"]))
+            .on_condition(date(Month.DECEMBER, 26).is_one_of([Weekday.SUNDAY, Weekday.MONDAY]))
 
     @staticmethod
     def birthday_of_the_sovereign(year):
@@ -181,21 +181,21 @@ class WA(Region):
         https://www.legislation.wa.gov.au/legislation/statutes.nsf/gazettes.html
         """
         dates = {
-            2011: date(month=10, day=28),  # 2010 234-6261
-            2012: date(month=10, day=1),  # 2008 229-5633
-            2013: date(month=9, day=30),  # 2008 229-5633
-            2014: date(month=9, day=29),  # 2012  61-1687
-            2015: date(month=9, day=28),  # 2012  61-1687
-            2016: date(month=9, day=26),  # 2014  74-1595
-            2017: date(month=9, day=25),  # 2014  74-1595
-            2018: date(month=9, day=24),  # 2016  73-1379
-            2019: date(month=9, day=30),  # 2016  73-1379
-            2020: date(month=9, day=28),  # 2018  53-1287
-            2021: date(month=9, day=27),  # 2018  53-1287
-            2022: date(month=9, day=26),  # 2020 151-2919
-            2023: date(month=9, day=25),  # 2020 151-2919
-            2024: date(month=9, day=23),  # 2022  69-3009
-            2025: date(month=9, day=29),  # 2022  69-3009
+            2011: date(Month.OCTOBER, 28),    # 2010 234-6261
+            2012: date(Month.OCTOBER, 1),     # 2008 229-5633
+            2013: date(Month.SEPTEMBER, 30),  # 2008 229-5633
+            2014: date(Month.SEPTEMBER, 29),  # 2012  61-1687
+            2015: date(Month.SEPTEMBER, 28),  # 2012  61-1687
+            2016: date(Month.SEPTEMBER, 26),  # 2014  74-1595
+            2017: date(Month.SEPTEMBER, 25),  # 2014  74-1595
+            2018: date(Month.SEPTEMBER, 24),  # 2016  73-1379
+            2019: date(Month.SEPTEMBER, 30),  # 2016  73-1379
+            2020: date(Month.SEPTEMBER, 28),  # 2018  53-1287
+            2021: date(Month.SEPTEMBER, 27),  # 2018  53-1287
+            2022: date(Month.SEPTEMBER, 26),  # 2020 151-2919
+            2023: date(Month.SEPTEMBER, 25),  # 2020 151-2919
+            2024: date(Month.SEPTEMBER, 23),  # 2022  69-3009
+            2025: date(Month.SEPTEMBER, 29),  # 2022  69-3009
         }
 
         return dates.get(year)(year) if year in dates else None

--- a/src/holidata/holidays/BE/__init__.py
+++ b/src/holidata/holidays/BE/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "BE",
@@ -22,7 +22,7 @@ class BE(Country):
                 "fr": "Nouvel An",
                 "nl": "Nieuwjaar",
             }) \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -31,7 +31,7 @@ class BE(Country):
                 "fr": "Fête du Travail",
                 "nl": "Dag van de arbeid",
             }) \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -40,7 +40,7 @@ class BE(Country):
                 "fr": "Fête nationale",
                 "nl": "Nationale feestdag",
             }) \
-            .on(date(month=7, day=21)) \
+            .on(date(Month.JULY, 21)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -49,7 +49,7 @@ class BE(Country):
                 "fr": "Assomption",
                 "nl": "Onze Lieve Vrouw hemelvaart",
             }) \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -58,7 +58,7 @@ class BE(Country):
                 "fr": "Toussaint",
                 "nl": "Allerheiligen",
             }) \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -67,7 +67,7 @@ class BE(Country):
                 "fr": "Jour de l'armistice",
                 "nl": "Wapenstilstand",
             }) \
-            .on(date(month=11, day=11)) \
+            .on(date(Month.NOVEMBER, 11)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -76,7 +76,7 @@ class BE(Country):
                 "fr": "Noël",
                 "nl": "Kerstmis",
             }) \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/BR/__init__.py
+++ b/src/holidata/holidays/BR/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "BR",
@@ -54,300 +54,300 @@ class BR(Country):
 
         self.define_holiday() \
             .with_name("Confraternização Universal") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Criação do Estado de Rondônia") \
             .in_regions(["RO"]) \
-            .on(date(month=1, day=4)) \
+            .on(date(Month.JANUARY, 4)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia do Evangélico no Acre") \
             .in_regions(["AC"]) \
-            .on(date(month=1, day=23)) \
+            .on(date(Month.JANUARY, 23)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Revolução Pernambucana de 1817") \
             .in_regions(["PE"]) \
-            .on(date(month=3, day=6)) \
+            .on(date(Month.MARCH, 6)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia Internacional da Mulher") \
             .in_regions(["AC"]) \
-            .on(date(month=3, day=8)) \
+            .on(date(Month.MARCH, 8)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Autonomia do Estado de Tocantins") \
             .in_regions(["TO"]) \
-            .on(date(month=3, day=18)) \
+            .on(date(Month.MARCH, 18)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia de São José") \
             .in_regions(["AP", "CE"]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Abolição da Escravidão no Ceará") \
             .in_regions(["CE"]) \
-            .on(date(month=3, day=25)) \
+            .on(date(Month.MARCH, 25)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Fundação de Brasília") \
             .in_regions(["DF"]) \
-            .on(date(month=4, day=21)) \
+            .on(date(Month.APRIL, 21)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Execução de Tiradentes") \
             .in_regions(["MG"]) \
-            .on(date(month=4, day=21)) \
+            .on(date(Month.APRIL, 21)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Tiradentes") \
-            .on(date(month=4, day=21)) \
+            .on(date(Month.APRIL, 21)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dia de São Jorge") \
             .in_regions(["RJ"]) \
-            .on(date(month=4, day=23)) \
+            .on(date(Month.APRIL, 23)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Dia Internacional do Trabalhador") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Aniversário do Estado do Acre") \
             .in_regions(["AC"]) \
-            .on(date(month=6, day=15)) \
+            .on(date(Month.JUNE, 15)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia do Evangélico em Rondônia") \
             .in_regions(["RO"]) \
-            .on(date(month=6, day=18)) \
+            .on(date(Month.JUNE, 18)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("São João") \
             .in_regions(["AL", "PE"]) \
-            .on(date(month=6, day=24)) \
+            .on(date(Month.JUNE, 24)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("São Pedro") \
             .in_regions(["AL"]) \
-            .on(date(month=6, day=29)) \
+            .on(date(Month.JUNE, 29)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Independência da Bahia") \
             .in_regions(["BA"]) \
-            .on(date(month=7, day=2)) \
+            .on(date(Month.JULY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Emancipação Política de Sergipe") \
             .in_regions(["SE"]) \
-            .on(date(month=7, day=8)) \
+            .on(date(Month.JULY, 8)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Revolução Constitucionalista de 1932") \
             .in_regions(["SP"]) \
-            .on(date(month=7, day=9)) \
+            .on(date(Month.JULY, 9)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Fundação da Cidade de Goiás") \
             .in_regions(["GO"]) \
-            .on(date(month=7, day=26)) \
+            .on(date(Month.JULY, 26)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Adesão do Maranhão à Independência do Brasil") \
             .in_regions(["MA"]) \
-            .on(date(month=7, day=28)) \
+            .on(date(Month.JULY, 28)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Fundação do Estado da Paraíba") \
             .in_regions(["PB"]) \
-            .on(date(month=8, day=5)) \
+            .on(date(Month.AUGUST, 5)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia do Rio Grande do Norte") \
             .in_regions(["RN"]) \
-            .on(date(month=8, day=7)) \
+            .on(date(Month.AUGUST, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia de Santa Catarina") \
             .in_regions(["SC"]) \
-            .on(date(month=8, day=11)) \
+            .on(date(Month.AUGUST, 11)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia de Nossa Senhora da Assunção") \
             .in_regions(["CE"]) \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Adesão do Pará à Independência do Brasil") \
             .in_regions(["PA"]) \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia da Amazônia") \
             .in_regions(["AC"]) \
-            .on(date(month=9, day=5)) \
+            .on(date(Month.SEPTEMBER, 5)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Elevação do Amazonas à Categoria de Província") \
             .in_regions(["AM"]) \
-            .on(date(month=9, day=5)) \
+            .on(date(Month.SEPTEMBER, 5)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Independência do Brasil") \
-            .on(date(month=9, day=7)) \
+            .on(date(Month.SEPTEMBER, 7)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Nossa Senhora da Natividade") \
             .in_regions(["TO"]) \
-            .on(date(month=9, day=8)) \
+            .on(date(Month.SEPTEMBER, 8)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Criação do Território Federal do Amapá") \
             .in_regions(["AP"]) \
-            .on(date(month=9, day=13)) \
+            .on(date(Month.SEPTEMBER, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Emancipação Política do Alagoas") \
             .in_regions(["AL"]) \
-            .on(date(month=9, day=16)) \
+            .on(date(Month.SEPTEMBER, 16)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia do Gaúcho") \
             .in_regions(["RS"]) \
-            .on(date(month=9, day=20)) \
+            .on(date(Month.SEPTEMBER, 20)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Mártires de Cunhaú e Uruaçu") \
             .in_regions(["RN"]) \
-            .on(date(month=10, day=3)) \
+            .on(date(Month.OCTOBER, 3)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Criação dos Estado de Roraima") \
             .in_regions(["RR"]) \
-            .on(date(month=10, day=5)) \
+            .on(date(Month.OCTOBER, 5)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Criação dos Estado de Tocantins") \
             .in_regions(["TO"]) \
-            .on(date(month=10, day=5)) \
+            .on(date(Month.OCTOBER, 5)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Criação do Estado do Mato Grosso do Sul") \
             .in_regions(["MS"]) \
-            .on(date(month=10, day=11)) \
+            .on(date(Month.OCTOBER, 11)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Nossa Senhora Aparecida") \
-            .on(date(month=10, day=12)) \
+            .on(date(Month.OCTOBER, 12)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Dia do Piauí") \
             .in_regions(["PI"]) \
-            .on(date(month=10, day=19)) \
+            .on(date(Month.OCTOBER, 19)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Pedra Fundamental de Goiânia") \
             .in_regions(["GO"]) \
-            .on(date(month=10, day=24)) \
+            .on(date(Month.OCTOBER, 24)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Finados") \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Proclamação da República") \
-            .on(date(month=11, day=15)) \
+            .on(date(Month.NOVEMBER, 15)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Assinatura do Tratado de Petrópolis") \
             .in_regions(["AC"]) \
-            .on(date(month=11, day=17)) \
+            .on(date(Month.NOVEMBER, 17)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Morte de Zumbi dos Palmares") \
             .in_regions(["AL"]) \
-            .on(date(month=11, day=20)) \
+            .on(date(Month.NOVEMBER, 20)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia da Consciência Negra") \
             .in_regions(["AM", "MT", "RJ"]) \
-            .on(date(month=11, day=20)) \
+            .on(date(Month.NOVEMBER, 20)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Dia de Santa Catarina de Alexandria") \
             .in_regions(["SC"]) \
-            .on(date(month=11, day=25)) \
+            .on(date(Month.NOVEMBER, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Dia do Evangélico do Distrito Federal") \
             .in_regions(["DF"]) \
-            .on(date(month=11, day=30)) \
+            .on(date(Month.NOVEMBER, 30)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Nossa Senhora da Conceição") \
             .in_regions(["AM"]) \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Emancipação Política do Estado do Paraná") \
             .in_regions(["PR"]) \
-            .on(date(month=12, day=19)) \
+            .on(date(Month.DECEMBER, 19)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Natal") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/CA/__init__.py
+++ b/src/holidata/holidays/CA/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, third, second, date
+from holidata.utils import day, first, third, second, date, Weekday, Month
 
 __all__ = [
     "CA",
@@ -45,7 +45,7 @@ class CA(Country):
                 "en": "New Year's Day",
                 "fr": "Jour de l'An",
             }) \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -54,7 +54,7 @@ class CA(Country):
                 "fr": "Fête Nationale",
             }) \
             .in_regions(["QC"]) \
-            .on(date(month=6, day=24)) \
+            .on(date(Month.JUNE, 24)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -62,7 +62,7 @@ class CA(Country):
                 "en": "Canada Day",
                 "fr": "Fête du Canada",
             }) \
-            .on(date(month=7, day=1)) \
+            .on(date(Month.JULY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -71,7 +71,7 @@ class CA(Country):
                 "fr": "Jour du Souvenir",
             }) \
             .in_regions(["AB", "BC", "NB", "NL", "NT"]) \
-            .on(date(month=11, day=11)) \
+            .on(date(Month.NOVEMBER, 11)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -79,7 +79,7 @@ class CA(Country):
                 "en": "Christmas Day",
                 "fr": "Jour de Noël",
             }) \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -87,7 +87,7 @@ class CA(Country):
                 "en": "Boxing Day",
                 "fr": "Lendemain de Noël",
             }) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -113,7 +113,7 @@ class CA(Country):
                 "fr": "Fête de la Famille",
             }) \
             .in_regions(["AB", "ON", "SK", "NB"]) \
-            .on(third("monday").of("february")) \
+            .on(third(Weekday.MONDAY).of(Month.FEBRUARY)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -122,7 +122,7 @@ class CA(Country):
                 "fr": "Journée Louis Riel",
             }) \
             .in_regions(["MB"]) \
-            .on(third("monday").of("february")) \
+            .on(third(Weekday.MONDAY).of(Month.FEBRUARY)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -131,7 +131,7 @@ class CA(Country):
                 "fr": "Fête des Insulaires",
             }) \
             .in_regions(["PE"]) \
-            .on(third("monday").of("february")) \
+            .on(third(Weekday.MONDAY).of(Month.FEBRUARY)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -140,7 +140,7 @@ class CA(Country):
                 "fr": "Premier lundi d'août",
             }) \
             .in_regions(["NT", "NU"]) \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -149,7 +149,7 @@ class CA(Country):
                 "fr": "Fête de la Saskatchewan",
             }) \
             .in_regions(["SK"]) \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -158,7 +158,7 @@ class CA(Country):
                 "fr": "Fête du Patrimoine",
             }) \
             .in_regions(["AB"]) \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -167,7 +167,7 @@ class CA(Country):
                 "fr": "Jour de la Fondation",
             }) \
             .in_regions(["NS"]) \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -176,7 +176,7 @@ class CA(Country):
                 "fr": "Jour du Nouveau-Brunswick",
             }) \
             .in_regions(["NB"]) \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -184,7 +184,7 @@ class CA(Country):
                 "en": "Labour Day",
                 "fr": "Fête du Travail",
             }) \
-            .on(first("monday").of("september")) \
+            .on(first(Weekday.MONDAY).of(Month.SEPTEMBER)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -193,7 +193,7 @@ class CA(Country):
                 "fr": "Jour de l'Action de grâce",
             }) \
             .in_regions(["AB", "BC", "MB", "NL", "ON", "QC", "SK", "NT", "NU", "YT"]) \
-            .on(second("monday").of("october")) \
+            .on(second(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -202,7 +202,7 @@ class CA(Country):
                 "fr": "Journée Nationale des Patriotes",
             }) \
             .in_regions(["QC"]) \
-            .on(first("monday").before(date(month=5, day=25))) \
+            .on(first(Weekday.MONDAY).before(date(Month.MAY, 25))) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -211,5 +211,5 @@ class CA(Country):
                 "fr": "Fête de la Reine Victoria",
             }) \
             .in_regions(["AB", "BC", "MB", "NS", "ON", "SK", "NT", "NU", "YT"]) \
-            .on(first("monday").before(date(month=5, day=25))) \
+            .on(first(Weekday.MONDAY).before(date(Month.MAY, 25))) \
             .with_flags("V")

--- a/src/holidata/holidays/CH/__init__.py
+++ b/src/holidata/holidays/CH/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "CH",
@@ -18,77 +18,77 @@ class CH(Country):
 
         self.define_holiday() \
             .with_name("Neujahrstag") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Berchtoldstag") \
             .in_regions(["BE", "JU", "TG", "VD"]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Heilige Drei Könige") \
             .in_regions(["SZ", "TI", "UR"]) \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Josefstag") \
             .in_regions(["NW", "SZ", "TI", "UR", "VS"]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Tag der Arbeit") \
             .in_regions(["BL", "BS", "GR", "NE", "SH", "TG", "TI", "ZH"]) \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Bundesfeier") \
-            .on(date(month=8, day=1)) \
+            .on(date(Month.AUGUST, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Mariä Himmelfahrt") \
             .in_regions(["AI"]) \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Mariä Himmelfahrt") \
             .in_regions(["JU", "LU", "NW", "OW", "SZ", "TI", "UR", "VS", "ZG"]) \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Allerheiligen") \
             .in_regions(["AI", "GL", "JU", "LU", "NW", "OW", "SG", "SZ", "TI", "UR", "VS", "ZG"]) \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Mariä Empfängnis") \
             .in_regions(["AI"]) \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Mariä Empfängnis") \
             .in_regions(["LU", "NW", "OW", "SZ", "TI", "UR", "VS", "ZG"]) \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Weihnachtstag") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Stephanstag") \
             .in_regions(["AI", "AR", "BE", "BL", "BS", "GL", "GR", "LU", "SG", "SH", "SZ", "TG", "TI", "UR", "ZH"]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/CO/__init__.py
+++ b/src/holidata/holidays/CO/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, date
+from holidata.utils import day, first, date, Weekday, Month
 
 __all__ = [
     "CO",
@@ -18,32 +18,32 @@ class CO(Country):
 
         self.define_holiday() \
             .with_name("Año Nuevo") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Día del Trabajo") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Grito de Independencia") \
-            .on(date(month=7, day=20)) \
+            .on(date(Month.JULY, 20)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Batalla de Boyacá") \
-            .on(date(month=8, day=7)) \
+            .on(date(Month.AUGUST, 7)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Inmaculada Concepción") \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Navidad") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -78,35 +78,35 @@ class CO(Country):
 
         self.define_holiday() \
             .with_name("Día de los Reyes Magos") \
-            .on(first("monday").after(date(month=1, day=6), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 6), including=True)) \
             .with_flags("NRV")
 
         self.define_holiday() \
             .with_name("Día de San José") \
-            .on(first("monday").after(date(month=3, day=19), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.MARCH, 19), including=True)) \
             .with_flags("NRV")
 
         self.define_holiday() \
             .with_name("San Pedro y San Pablo") \
-            .on(first("monday").after(date(month=6, day=29), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.JUNE, 29), including=True)) \
             .with_flags("NRV")
 
         self.define_holiday() \
             .with_name("Asunción de la Virgen") \
-            .on(first("monday").after(date(month=8, day=15), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.AUGUST, 15), including=True)) \
             .with_flags("NRV")
 
         self.define_holiday() \
             .with_name("Día de la Raza") \
-            .on(first("monday").after(date(month=10, day=12), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.OCTOBER, 12), including=True)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Todos los Santos") \
-            .on(first("monday").after(date(month=11, day=1), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.NOVEMBER, 1), including=True)) \
             .with_flags("NRV")
 
         self.define_holiday() \
             .with_name("Independencia de Cartagena") \
-            .on(first("monday").after(date(month=11, day=11), including=True)) \
+            .on(first(Weekday.MONDAY).after(date(Month.NOVEMBER, 11), including=True)) \
             .with_flags("NV")

--- a/src/holidata/holidays/CZ/__init__.py
+++ b/src/holidata/holidays/CZ/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "CZ",
@@ -26,57 +26,57 @@ class CZ(Country):
 
         self.define_holiday() \
             .with_name("Nový rok") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Den obnovy samostatného českého státu") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Svátek práce") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Den vítězství") \
-            .on(date(month=5, day=8)) \
+            .on(date(Month.MAY, 8)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Den slovanských věrozvěstů Cyrila a Metoděje") \
-            .on(date(month=7, day=5)) \
+            .on(date(Month.JULY, 5)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Den upálení mistra Jana Husa") \
-            .on(date(month=7, day=6)) \
+            .on(date(Month.JULY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Den české státnosti") \
-            .on(date(month=9, day=28)) \
+            .on(date(Month.SEPTEMBER, 28)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Den vzniku samostatného československého státu") \
-            .on(date(month=10, day=28)) \
+            .on(date(Month.OCTOBER, 28)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Štědrý den") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("1. svátek vánoční") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("2. svátek vánoční") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -95,7 +95,7 @@ class CZ(Country):
         """
         self.define_holiday() \
             .with_name("Den boje za svobodu a demokracii") \
-            .on(date(month=11, day=17)) \
+            .on(date(Month.NOVEMBER, 17)) \
             .until(2018) \
             .with_flags("NF")
 
@@ -104,6 +104,6 @@ class CZ(Country):
         """
         self.define_holiday() \
             .with_name("Den boje za svobodu a demokracii a Mezinárodní den studentstva") \
-            .on(date(month=11, day=17)) \
+            .on(date(Month.NOVEMBER, 17)) \
             .since(2019) \
             .with_flags("NF")

--- a/src/holidata/holidays/DE/BB.py
+++ b/src/holidata/holidays/DE/BB.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class BB(Region):
@@ -12,11 +12,11 @@ class BB(Region):
         self.define_holiday() \
             .with_name("Reformationstag") \
             .until(2016) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/BE.py
+++ b/src/holidata/holidays/DE/BE.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class BE(Region):
@@ -22,7 +22,7 @@ class BE(Region):
         self.define_holiday() \
             .with_name("75. Jahrestag der Befreiung vom Nationalsozialismus und der Beendigung des Zweiten Weltkrieges in Europa") \
             .in_years([2020]) \
-            .on(date(month=5, day=8)) \
+            .on(date(Month.MAY, 8)) \
             .with_flags("F")
 
         """
@@ -33,5 +33,5 @@ class BE(Region):
         self.define_holiday() \
             .with_name("Internationaler Frauentag") \
             .since(2019) \
-            .on(date(month=3, day=8)) \
+            .on(date(Month.MARCH, 8)) \
             .with_flags("F")

--- a/src/holidata/holidays/DE/BW.py
+++ b/src/holidata/holidays/DE/BW.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class BW(Region):
@@ -8,12 +8,12 @@ class BW(Region):
 
         self.define_holiday() \
             .with_name("Heilige drei Könige") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Allerheiligen") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("RF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/DE/BY.py
+++ b/src/holidata/holidays/DE/BY.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class BY(Region):
@@ -11,18 +11,18 @@ class BY(Region):
 
         self.define_holiday() \
             .with_name("Heilige drei Könige") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Mariä Himmelfahrt") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("RF") \
             .annotated_with("In Gemeinden mit überwiegend katholischer Bevölkerung")
 
         self.define_holiday() \
             .with_name("Allerheiligen") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("RF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/DE/HB.py
+++ b/src/holidata/holidays/DE/HB.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class HB(Region):
@@ -9,5 +9,5 @@ class HB(Region):
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/HH.py
+++ b/src/holidata/holidays/DE/HH.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class HH(Region):
@@ -9,5 +9,5 @@ class HH(Region):
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/MV.py
+++ b/src/holidata/holidays/DE/MV.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class MV(Region):
@@ -9,11 +9,11 @@ class MV(Region):
         self.define_holiday() \
             .with_name("Reformationstag") \
             .until(2016) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/NI.py
+++ b/src/holidata/holidays/DE/NI.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class NI(Region):
@@ -9,5 +9,5 @@ class NI(Region):
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/NW.py
+++ b/src/holidata/holidays/DE/NW.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class NW(Region):
@@ -8,7 +8,7 @@ class NW(Region):
 
         self.define_holiday() \
             .with_name("Allerheiligen") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("RF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/DE/RP.py
+++ b/src/holidata/holidays/DE/RP.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class RP(Region):
@@ -8,7 +8,7 @@ class RP(Region):
 
         self.define_holiday() \
             .with_name("Allerheiligen") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("RF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/DE/SH.py
+++ b/src/holidata/holidays/DE/SH.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class SH(Region):
@@ -9,5 +9,5 @@ class SH(Region):
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/SL.py
+++ b/src/holidata/holidays/DE/SL.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class SL(Region):
@@ -11,12 +11,12 @@ class SL(Region):
 
         self.define_holiday() \
             .with_name("Mariä Himmelfahrt") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Allerheiligen") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("RF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/DE/SN.py
+++ b/src/holidata/holidays/DE/SN.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, fourth, date
+from holidata.utils import day, fourth, date, Weekday, Month
 
 
 class SN(Region):
@@ -11,17 +11,17 @@ class SN(Region):
         """
         self.define_holiday() \
             .with_name("Buß- und Bettag") \
-            .on(day(11).before(fourth("sunday").before(date(month=12, day=25)))) \
+            .on(day(11).before(fourth(Weekday.SUNDAY).before(date(Month.DECEMBER, 25)))) \
             .with_flags("RV")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .until(2016) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/ST.py
+++ b/src/holidata/holidays/DE/ST.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import date
+from holidata.utils import date, Month
 
 
 class ST(Region):
@@ -8,17 +8,17 @@ class ST(Region):
 
         self.define_holiday() \
             .with_name("Heilige drei Könige") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .until(2016) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")

--- a/src/holidata/holidays/DE/TH.py
+++ b/src/holidata/holidays/DE/TH.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class TH(Region):
@@ -22,25 +22,26 @@ class TH(Region):
 
      Holidays marked with '*' are already covered by the definitions in __init__.py
     """
+
     def __init__(self, country):
         super().__init__("TH", country)
 
         self.define_holiday() \
             .with_name("Weltkindertag") \
             .since(2019) \
-            .on(date(month=9, day=20)) \
+            .on(date(Month.SEPTEMBER, 20)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .until(2016) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Reformationstag") \
             .since(2018) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("RF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/DE/__init__.py
+++ b/src/holidata/holidays/DE/__init__.py
@@ -17,7 +17,7 @@ from holidata.holidays.DE.SL import SL
 from holidata.holidays.DE.SN import SN
 from holidata.holidays.DE.ST import ST
 from holidata.holidays.DE.TH import TH
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "DE",
@@ -56,37 +56,37 @@ class DE(Country):
 
         self.define_holiday() \
             .with_name("Neujahr") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Erster Maifeiertag") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Tag der Deutschen Einheit") \
-            .on(date(month=10, day=3)) \
+            .on(date(Month.OCTOBER, 3)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Heilig Abend") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Weihnachtstag") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Zweiter Weihnachtstag") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Silvester") \
-            .on(date(month=12, day=31)) \
+            .on(date(Month.DECEMBER, 31)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -125,5 +125,5 @@ class DE(Country):
         self.define_holiday() \
             .with_name("Reformationstag") \
             .in_years([2017]) \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("NRF")

--- a/src/holidata/holidays/DK/__init__.py
+++ b/src/holidata/holidays/DK/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "DK",
@@ -18,22 +18,22 @@ class DK(Country):
 
         self.define_holiday() \
             .with_name("Nytårsdag") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Grundlovsdag") \
-            .on(date(month=6, day=5)) \
+            .on(date(Month.JUNE, 5)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Juledag") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Anden juledag") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/EE/__init__.py
+++ b/src/holidata/holidays/EE/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "EE",
@@ -23,47 +23,47 @@ class EE(Country):
 
         self.define_holiday() \
             .with_name("Uusaasta") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Iseseisvuspäev, Eesti Vabariigi aastapäev") \
-            .on(date(month=2, day=24)) \
+            .on(date(Month.FEBRUARY, 24)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Kevadpüha") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Võidupüha") \
-            .on(date(month=6, day=23)) \
+            .on(date(Month.JUNE, 23)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Jaanipäev") \
-            .on(date(month=6, day=24)) \
+            .on(date(Month.JUNE, 24)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Taasiseseisvumispäev") \
-            .on(date(month=8, day=20)) \
+            .on(date(Month.AUGUST, 20)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Jõululaupäev") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Esimene jõulupüha") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Teine jõulupüha") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/ES/AN.py
+++ b/src/holidata/holidays/ES/AN.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class AN(Region):
@@ -9,13 +9,13 @@ class AN(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Año Nuevo") \
             .in_years([2017, 2023]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -26,13 +26,13 @@ class AN(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Asunción de la Virgen") \
             .in_years([2021]) \
-            .on(date(month=8, day=16)) \
+            .on(date(Month.AUGUST, 16)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013, 2019, 2024]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -43,44 +43,44 @@ class AN(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011, 2016, 2022]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta Nacional de España") \
             .in_years([2014, 2025]) \
-            .on(date(month=10, day=13)) \
+            .on(date(Month.OCTOBER, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
     @staticmethod
     def dia_de_andalucia(year):
         if year == 2016:
-            return date(2, 29)(year)
+            return date(Month.FEBRUARY, 29)(year)
         elif year == 2021:
-            return date(3, 1)(year)
+            return date(Month.MARCH, 1)(year)
         else:
-            return date(2, 28)(year)
+            return date(Month.FEBRUARY, 28)(year)

--- a/src/holidata/holidays/ES/AR.py
+++ b/src/holidata/holidays/ES/AR.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class AR(Region):
@@ -9,13 +9,13 @@ class AR(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Año Nuevo") \
             .in_years([2017, 2023]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -26,19 +26,19 @@ class AR(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a San Jorge / Día de Aragón") \
             .in_years([2023]) \
-            .on(date(month=4, day=24)) \
+            .on(date(Month.APRIL, 24)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Asunción de la Virgen") \
             .in_years([2021]) \
-            .on(date(month=8, day=16)) \
+            .on(date(Month.AUGUST, 16)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013, 2019, 2024]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -49,42 +49,42 @@ class AR(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011, 2016, 2022]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta Nacional de España") \
             .in_years([2014, 2025]) \
-            .on(date(month=10, day=13)) \
+            .on(date(Month.OCTOBER, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
     @staticmethod
     def holiday_san_jorge__dia_de_aragon(year):
         if year == 2017:
-            return date(4, 24)(year)
+            return date(Month.APRIL, 24)(year)
         else:
-            return date(4, 23)(year)
+            return date(Month.APRIL, 23)(year)

--- a/src/holidata/holidays/ES/AS.py
+++ b/src/holidata/holidays/ES/AS.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class AS(Region):
@@ -9,43 +9,43 @@ class AS(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Año Nuevo") \
             .in_years([2017, 2023]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Asunción de la Virgen") \
             .in_years([2021]) \
-            .on(date(month=8, day=16)) \
+            .on(date(Month.AUGUST, 16)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de Asturias") \
             .except_for([2019]) \
-            .on(date(month=9, day=8)) \
+            .on(date(Month.SEPTEMBER, 8)) \
             .with_flags("F"),
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de Asturias") \
             .in_years([2013, 2019, 2024]) \
-            .on(date(month=9, day=9)) \
+            .on(date(Month.SEPTEMBER, 9)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013, 2019, 2024]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -56,29 +56,29 @@ class AS(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011, 2016, 2022]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta Nacional de España") \
             .in_years([2014, 2025]) \
-            .on(date(month=10, day=13)) \
+            .on(date(Month.OCTOBER, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/CB.py
+++ b/src/holidata/holidays/ES/CB.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class CB(Region):
@@ -9,19 +9,19 @@ class CB(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de las Instituciones de Cantabria") \
             .in_years([2011, 2016, 2017, 2018, 2020, 2021, 2022, 2023, 2025, 2026]) \
-            .on(date(month=7, day=28)) \
+            .on(date(Month.JULY, 28)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("La Bien Aparecida") \
             .in_years([2011, 2012, 2014, 2014, 2015, 2016, 2017, 2018, 2020, 2021, 2022, 2023, 2025, 2026]) \
-            .on(date(month=9, day=15)) \
+            .on(date(Month.SEPTEMBER, 15)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -39,47 +39,47 @@ class CB(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol") \
             .in_years([2012, 2013, 2014, 2019]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol / Día Nacional de Galicia") \
             .in_years([2024]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2019]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/CE.py
+++ b/src/holidata/holidays/ES/CE.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class CE(Region):
@@ -9,19 +9,19 @@ class CE(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Nuestra Señora de África") \
             .in_years([2022, 2023, 2024, 2025, 2026]) \
-            .on(date(month=8, day=5)) \
+            .on(date(Month.AUGUST, 5)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de Ceuta") \
             .in_years([2016, 2017, 2019, 2020, 2021, 2022, 2023, 2026]) \
-            .on(date(month=9, day=2)) \
+            .on(date(Month.SEPTEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -33,7 +33,7 @@ class CE(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Sacrificio (Eidul Adha)") \
             .in_years([2011]) \
-            .on(date(month=11, day=7)) \
+            .on(date(Month.NOVEMBER, 7)) \
             .with_flags("RV")
 
         self.define_holiday() \
@@ -44,57 +44,57 @@ class CE(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta Nacional de España") \
             .in_years([2014]) \
-            .on(date(month=10, day=13)) \
+            .on(date(Month.OCTOBER, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
     @staticmethod
     def day_of_eidul_adha(year):
         dates = {
-            2012: date(10, 27),
-            2013: date(10, 15),
-            2014: date(10, 6),
-            2015: date(9, 25),
-            2016: date(9, 12),
-            2017: date(9, 1),
-            2018: date(8, 22),
-            2019: date(8, 12),
-            2020: date(7, 31),
-            2021: date(7, 20),
-            2022: date(7, 9),
-            2023: date(6, 29),
-            2024: date(6, 17),
-            2025: date(6, 6),
-            2026: date(5, 27),
+            2012: date(Month.OCTOBER, 27),
+            2013: date(Month.OCTOBER, 15),
+            2014: date(Month.OCTOBER, 6),
+            2015: date(Month.SEPTEMBER, 25),
+            2016: date(Month.SEPTEMBER, 12),
+            2017: date(Month.SEPTEMBER, 1),
+            2018: date(Month.AUGUST, 22),
+            2019: date(Month.AUGUST, 12),
+            2020: date(Month.JULY, 31),
+            2021: date(Month.JULY, 20),
+            2022: date(Month.JULY, 9),
+            2023: date(Month.JUNE, 29),
+            2024: date(Month.JUNE, 17),
+            2025: date(Month.JUNE, 6),
+            2026: date(Month.MAY, 27),
         }
 
         return dates.get(year)(year) if year in dates else None

--- a/src/holidata/holidays/ES/CL.py
+++ b/src/holidata/holidays/ES/CL.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class CL(Region):
@@ -9,13 +9,13 @@ class CL(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Año Nuevo") \
             .in_years([2017, 2023]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -26,43 +26,43 @@ class CL(Region):
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2012]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol / Día Nacional de Galicia") \
             .in_years([2023]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Asunción de la Virgen") \
             .in_years([2021]) \
-            .on(date(month=8, day=16)) \
+            .on(date(Month.AUGUST, 16)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta Nacional de España") \
             .in_years([2014, 2025]) \
-            .on(date(month=10, day=13)) \
+            .on(date(Month.OCTOBER, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013, 2019, 2024]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -79,30 +79,30 @@ class CL(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2016, 2022]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol") \
             .in_years([2011]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016, 2018]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
     @staticmethod
     def day_fiesta_de_castilla_y_leon(year):
         if year == 2017:
-            return date(4, 24)(year)
+            return date(Month.APRIL, 24)(year)
         else:
-            return date(4, 23)(year)
+            return date(Month.APRIL, 23)(year)

--- a/src/holidata/holidays/ES/CM.py
+++ b/src/holidata/holidays/ES/CM.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class CM(Region):
@@ -9,13 +9,13 @@ class CM(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de Castilla-La Mancha") \
             .except_for([2014, 2015, 2020]) \
-            .on(date(month=5, day=31)) \
+            .on(date(Month.MAY, 31)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -27,7 +27,7 @@ class CM(Region):
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2011, 2020]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -44,23 +44,23 @@ class CM(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/CN.py
+++ b/src/holidata/holidays/ES/CN.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class CN(Region):
@@ -9,13 +9,13 @@ class CN(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de Canarias") \
             .except_for([2021]) \
-            .on(date(month=5, day=30)) \
+            .on(date(Month.MAY, 30)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -32,35 +32,35 @@ class CN(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2016]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Asunción de la Virgen") \
             .in_years([2021]) \
-            .on(date(month=8, day=16)) \
+            .on(date(Month.AUGUST, 16)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015, 2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2020]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/CT.py
+++ b/src/holidata/holidays/ES/CT.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class CT(Region):
@@ -9,13 +9,13 @@ class CT(Region):
         self.define_holiday() \
             .with_name("San Juan") \
             .in_years([2011, 2013, 2014, 2015, 2016, 2017, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]) \
-            .on(date(month=6, day=24)) \
+            .on(date(Month.JUNE, 24)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Fiesta Nacional de Cataluña") \
             .except_for([2011, 2016, 2022]) \
-            .on(date(month=9, day=11)) \
+            .on(date(Month.SEPTEMBER, 11)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -33,5 +33,5 @@ class CT(Region):
         self.define_holiday() \
             .with_name("San Esteban") \
             .except_for([2018, 2021]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/EX.py
+++ b/src/holidata/holidays/ES/EX.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class EX(Region):
@@ -9,7 +9,7 @@ class EX(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -21,49 +21,49 @@ class EX(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a San José") \
             .in_years([2017]) \
-            .on(date(month=3, day=20)) \
+            .on(date(Month.MARCH, 20)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de Extremadura") \
             .except_for([2019, 2024]) \
-            .on(date(month=9, day=8)) \
+            .on(date(Month.SEPTEMBER, 8)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de Extremadura") \
             .in_years([2013, 2019]) \
-            .on(date(month=9, day=9)) \
+            .on(date(Month.SEPTEMBER, 9)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2021]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta Nacional de España") \
             .in_years([2014, 2025]) \
-            .on(date(month=10, day=13)) \
+            .on(date(Month.OCTOBER, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013, 2019, 2024]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -74,17 +74,17 @@ class EX(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011, 2016, 2022]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/GA.py
+++ b/src/holidata/holidays/ES/GA.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class GA(Region):
@@ -9,37 +9,37 @@ class GA(Region):
         self.define_holiday() \
             .with_name("San Juan") \
             .in_years([2013, 2016, 2020, 2022, 2026]) \
-            .on(date(month=6, day=24)) \
+            .on(date(Month.JUNE, 24)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2011, 2019, 2020, 2021, 2026]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día siguiente a San José") \
             .in_years([2015]) \
-            .on(date(month=3, day=20)) \
+            .on(date(Month.MARCH, 20)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de las Letras Gallegas") \
             .except_for([2015, 2020]) \
-            .on(date(month=5, day=17)) \
+            .on(date(Month.MAY, 17)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol / Día Nacional de Galicia") \
             .except_for([2021]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \

--- a/src/holidata/holidays/ES/IB.py
+++ b/src/holidata/holidays/ES/IB.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class IB(Region):
@@ -9,13 +9,13 @@ class IB(Region):
         self.define_holiday() \
             .with_name("Día de las Illes Balears") \
             .in_years([2011, 2012, 2013, 2014, 2016, 2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025, 2026]) \
-            .on(date(month=3, day=1)) \
+            .on(date(Month.MARCH, 1)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de las Illes Balears") \
             .in_years([2026]) \
-            .on(date(month=3, day=2)) \
+            .on(date(Month.MARCH, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -32,23 +32,23 @@ class IB(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2015]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2013, 2014, 2016, 2019, 2020, 2025, 2026]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/MC.py
+++ b/src/holidata/holidays/ES/MC.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class MC(Region):
@@ -9,13 +9,13 @@ class MC(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Año Nuevo") \
             .in_years([2017, 2023]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -27,13 +27,13 @@ class MC(Region):
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2011, 2012, 2013, 2014, 2015, 2016, 2018, 2019, 2020, 2021, 2024, 2025, 2026]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013, 2024]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -50,30 +50,30 @@ class MC(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011, 2022]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
     @staticmethod
     def dia_de_la_region_de_murcia(year):
         if year == 2019:
-            return date(6, 10)(year)
+            return date(Month.JUNE, 10)(year)
         else:
-            return date(6, 9)(year)
+            return date(Month.JUNE, 9)(year)

--- a/src/holidata/holidays/ES/MD.py
+++ b/src/holidata/holidays/ES/MD.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class MD(Region):
@@ -9,31 +9,31 @@ class MD(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Traslado de San José") \
             .in_years([2013]) \
-            .on(date(month=3, day=18)) \
+            .on(date(Month.MARCH, 18)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a San José") \
             .in_years([2017, 2023]) \
-            .on(date(month=3, day=20)) \
+            .on(date(Month.MARCH, 20)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Fiesta de la Comunidad de Madrid") \
             .except_for([2016, 2021]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Comunidad de Madrid") \
             .in_years([2021]) \
-            .on(date(month=5, day=3)) \
+            .on(date(Month.MAY, 3)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -45,7 +45,7 @@ class MD(Region):
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2012, 2015, 2021, 2023]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -56,47 +56,47 @@ class MD(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2016]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol") \
             .in_years([2011, 2016, 2022]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol / Día Nacional de Galicia") \
             .in_years([2024, 2025]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2020, 2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2019]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/ML.py
+++ b/src/holidata/holidays/ES/ML.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class ML(Region):
@@ -9,19 +9,19 @@ class ML(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Año Nuevo") \
             .in_years([2017]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Estatuto de Autonomía de la Ciudad de Melilla") \
             .in_years([2020, 2021]) \
-            .on(date(month=3, day=13)) \
+            .on(date(Month.MARCH, 13)) \
             .with_flags("F")
 
         self.define_holiday() \
@@ -45,7 +45,7 @@ class ML(Region):
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2011, 2012, 2013, 2014, 2015, 2016]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -56,61 +56,61 @@ class ML(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2019, 2024]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
     @staticmethod
     def holiday_aid_el_kebir(year):
         dates = {
-            2011: date(11, 7),
-            2012: date(10, 26),
-            2013: date(10, 15),
-            2014: date(10, 4),
-            2015: date(9, 25),
-            2016: date(9, 12),
-            2017: date(9, 1),
-            2018: date(8, 22),
-            2019: date(8, 12),
-            2020: date(7, 31),
-            2021: date(7, 21),
+            2011: date(Month.NOVEMBER, 7),
+            2012: date(Month.OCTOBER, 26),
+            2013: date(Month.OCTOBER, 15),
+            2014: date(Month.OCTOBER, 4),
+            2015: date(Month.SEPTEMBER, 25),
+            2016: date(Month.SEPTEMBER, 12),
+            2017: date(Month.SEPTEMBER, 1),
+            2018: date(Month.AUGUST, 22),
+            2019: date(Month.AUGUST, 12),
+            2020: date(Month.JULY, 31),
+            2021: date(Month.JULY, 21),
         }
         return dates.get(year)(year) if year in dates else None
 
     @staticmethod
     def holiday_aid_al_adha(year):
         dates = {
-            2022: date(7, 11),
-            2023: date(6, 29),
-            2024: date(6, 17),
-            2025: date(6, 6),
-            2026: date(5, 27),
+            2022: date(Month.JULY, 11),
+            2023: date(Month.JUNE, 29),
+            2024: date(Month.JUNE, 17),
+            2025: date(Month.JUNE, 6),
+            2026: date(Month.MAY, 27),
         }
         return dates.get(year)(year) if year in dates else None
 
     @staticmethod
     def day_of_eid_fitr(year):
         dates = {
-            2022: date(5, 3),
-            2023: date(4, 21),
-            2025: date(3, 31),
-            2026: date(3, 20),
+            2022: date(Month.MAY, 3),
+            2023: date(Month.APRIL, 21),
+            2025: date(Month.MARCH, 31),
+            2026: date(Month.MARCH, 20),
         }
         return dates.get(year)(year) if year in dates else None

--- a/src/holidata/holidays/ES/NC.py
+++ b/src/holidata/holidays/ES/NC.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class NC(Region):
@@ -9,19 +9,19 @@ class NC(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Epifanía del Señor") \
             .in_years([2013, 2019]) \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2012, 2014, 2015, 2019, 2020, 2021, 2026]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol / Día Nacional de Galicia") \
             .in_years([2023, 2024, 2025]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -37,29 +37,29 @@ class NC(Region):
         self.define_holiday() \
             .with_name("Santiago Apóstol") \
             .in_years([2011, 2013, 2015, 2016, 2017, 2022]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a Todos los Santos") \
             .in_years([2026]) \
-            .on(date(month=11, day=2)) \
+            .on(date(Month.NOVEMBER, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2020]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2011, 2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/PV.py
+++ b/src/holidata/holidays/ES/PV.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class PV(Region):
@@ -9,25 +9,25 @@ class PV(Region):
         self.define_holiday() \
             .with_name("V Centenario Vuelta al Mundo") \
             .in_years([2022]) \
-            .on(date(month=9, day=6)) \
+            .on(date(Month.SEPTEMBER, 6)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("80º aniversario del primer Gobierno Vasco") \
             .in_years([2016]) \
-            .on(date(month=10, day=7)) \
+            .on(date(Month.OCTOBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Día del País Vasco-Euskadiko Eguna") \
             .in_years([2011, 2012, 2013, 2014]) \
-            .on(date(month=10, day=25)) \
+            .on(date(Month.OCTOBER, 25)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2015, 2019, 2020, 2021, 2026]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -44,12 +44,12 @@ class PV(Region):
         self.define_holiday() \
             .with_name("Santiago Apóstol") \
             .in_years([2011, 2013, 2015, 2016, 2017, 2019, 2020, 2022]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Santiago Apóstol / Día Nacional de Galicia") \
             .in_years([2023, 2024, 2025, 2026]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 

--- a/src/holidata/holidays/ES/RI.py
+++ b/src/holidata/holidays/ES/RI.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class RI(Region):
@@ -14,13 +14,13 @@ class RI(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de La Rioja") \
             .in_years([2024]) \
-            .on(date(month=6, day=10)) \
+            .on(date(Month.JUNE, 10)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2012]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -38,30 +38,30 @@ class RI(Region):
         self.define_holiday() \
             .with_name("Santiago Apóstol") \
             .in_years([2011, 2016]) \
-            .on(date(month=7, day=25)) \
+            .on(date(Month.JULY, 25)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015, 2020, 2026]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a La Inmaculada Concepción") \
             .in_years([2013, 2019]) \
-            .on(date(month=12, day=9)) \
+            .on(date(Month.DECEMBER, 9)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Lunes siguiente a la Natividad del Señor") \
             .in_years([2022]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")
 
     @staticmethod
     def dia_de_la_rioja(year):
         if year in [2013, 2019]:
-            return date(6, 10)(year)
+            return date(Month.JUNE, 10)(year)
         else:
-            return date(6, 9)(year)
+            return date(Month.JUNE, 9)(year)

--- a/src/holidata/holidays/ES/VC.py
+++ b/src/holidata/holidays/ES/VC.py
@@ -1,5 +1,5 @@
 from holidata.holiday import Region
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 
 class VC(Region):
@@ -9,25 +9,25 @@ class VC(Region):
         self.define_holiday() \
             .with_name("Lunes de Fallas") \
             .in_years([2013]) \
-            .on(date(month=3, day=18)) \
+            .on(date(Month.MARCH, 18)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("San Juan") \
             .in_years([2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]) \
-            .on(date(month=6, day=24)) \
+            .on(date(Month.JUNE, 24)) \
             .with_flags("RF")
 
         self.define_holiday() \
             .with_name("Día de la Comunitat Valenciana") \
             .except_for([2011, 2016, 2022]) \
-            .on(date(month=10, day=9)) \
+            .on(date(Month.OCTOBER, 9)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("San José") \
             .in_years([2011, 2012, 2013, 2014, 2015, 2016, 2018, 2019, 2020, 2021, 2022, 2024, 2025, 2026]) \
-            .on(date(month=3, day=19)) \
+            .on(date(Month.MARCH, 19)) \
             .with_flags("RF")
 
         self.define_holiday() \
@@ -45,17 +45,17 @@ class VC(Region):
         self.define_holiday() \
             .with_name("Lunes siguiente a la Fiesta del Trabajo") \
             .in_years([2011]) \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("Lunes siguiente al Día de la Constitución Española") \
             .in_years([2015]) \
-            .on(date(month=12, day=7)) \
+            .on(date(Month.DECEMBER, 7)) \
             .with_flags("F")
 
         self.define_holiday() \
             .with_name("San Esteban") \
             .in_years([2016]) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("RF")

--- a/src/holidata/holidays/ES/__init__.py
+++ b/src/holidata/holidays/ES/__init__.py
@@ -20,7 +20,7 @@ from holidata.holidays.ES.NC import NC
 from holidata.holidays.ES.PV import PV
 from holidata.holidays.ES.RI import RI
 from holidata.holidays.ES.VC import VC
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "ES"
@@ -93,47 +93,47 @@ class ES(Country):
 
         self.define_holiday() \
             .with_name("Año Nuevo") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Epifanía del Señor") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Fiesta del Trabajo") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Asunción de la Virgen") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Fiesta Nacional de España") \
-            .on(date(month=10, day=12)) \
+            .on(date(Month.OCTOBER, 12)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Todos los Santos") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Día de la Constitución Española") \
-            .on(date(month=12, day=6)) \
+            .on(date(Month.DECEMBER, 6)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Inmaculada Concepción") \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Natividad del Señor") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -149,5 +149,5 @@ class ES(Country):
         self.define_holiday() \
             .with_name("Lunes siguiente al Año Nuevo") \
             .in_years([2012]) \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("NF")

--- a/src/holidata/holidays/FI/__init__.py
+++ b/src/holidata/holidays/FI/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, date
+from holidata.utils import day, first, date, Weekday, Month
 
 __all__ = [
     "FI",
@@ -25,7 +25,7 @@ class FI(Country):
                 "fi": "Uudenvuodenpäivä",
                 "sv": "Nyårsdagen",
             }) \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -33,7 +33,7 @@ class FI(Country):
                 "fi": "Loppiainen",
                 "sv": "Trettondedagen",
             }) \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -41,7 +41,7 @@ class FI(Country):
                 "fi": "Vappu",
                 "sv": "Första maj",
             }) \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -49,7 +49,7 @@ class FI(Country):
                 "fi": "Itsenäisyyspäivä",
                 "sv": "Självständighetsdagen",
             }) \
-            .on(date(month=12, day=6)) \
+            .on(date(Month.DECEMBER, 6)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -57,7 +57,7 @@ class FI(Country):
                 "fi": "Joulupäivä",
                 "sv": "Juldagen",
             }) \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -65,7 +65,7 @@ class FI(Country):
                 "fi": "Tapaninpäivä",
                 "sv": "Annandag jul",
             }) \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -116,7 +116,7 @@ class FI(Country):
                 "fi": "Juhannuspäivä",
                 "sv": "Midsommardagen",
             }) \
-            .on(first("saturday").after(date(month=6, day=19))) \
+            .on(first(Weekday.SATURDAY).after(date(Month.JUNE, 19))) \
             .with_flags("NRV")
 
         """
@@ -127,5 +127,5 @@ class FI(Country):
                 "fi": "Pyhäinpäivä",
                 "sv": "Alla helgons dag",
             }) \
-            .on(first("saturday").after(date(month=10, day=30))) \
+            .on(first(Weekday.SATURDAY).after(date(Month.OCTOBER, 30))) \
             .with_flags("NRV")

--- a/src/holidata/holidays/FR/__init__.py
+++ b/src/holidata/holidays/FR/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "FR",
@@ -18,42 +18,42 @@ class FR(Country):
 
         self.define_holiday() \
             .with_name("Jour de l'an") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Fête du premier mai") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Armistice 1945") \
-            .on(date(month=5, day=8)) \
+            .on(date(Month.MAY, 8)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Fête nationale") \
-            .on(date(month=7, day=14)) \
+            .on(date(Month.JULY, 14)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Assomption") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Toussaint") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Armistice 1918") \
-            .on(date(month=11, day=11)) \
+            .on(date(Month.NOVEMBER, 11)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Noël") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/GB/__init__.py
+++ b/src/holidata/holidays/GB/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, last, date
+from holidata.utils import day, first, last, date, Weekday, Month
 
 __all__ = [
     "GB",
@@ -18,48 +18,48 @@ class GB(Country):
 
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("NV") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("NV")  \
-            .on_condition(date(month=12, day=25).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=25))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("NV")  \
-            .on_condition(date(month=12, day=25).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26), including=False)) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26), including=False)) \
             .with_flags("NV")  \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26), including=False)) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26), including=False)) \
             .with_flags("NV")  \
-            .on_condition(date(month=12, day=26).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Good Friday") \
@@ -73,12 +73,12 @@ class GB(Country):
 
         self.define_holiday() \
             .with_name("Early May Bank Holiday") \
-            .on(first("monday").of("may")) \
+            .on(first(Weekday.MONDAY).of(Month.MAY)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("August Bank Holiday") \
-            .on(last("monday").of("august")) \
+            .on(last(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -92,7 +92,7 @@ class GB(Country):
         self.define_holiday() \
             .with_name("Coronation of King Charles III") \
             .in_years([2023]) \
-            .on(date(month=5, day=8)) \
+            .on(date(Month.MAY, 8)) \
             .with_flags("NV")
 
         """
@@ -101,7 +101,7 @@ class GB(Country):
         self.define_holiday() \
             .with_name("Queen's Diamond Jubilee") \
             .in_years([2012]) \
-            .on(date(month=6, day=5)) \
+            .on(date(Month.JUNE, 5)) \
             .with_flags("NV")
 
         """
@@ -110,7 +110,7 @@ class GB(Country):
         self.define_holiday() \
             .with_name("Queen's Platinum Jubilee") \
             .in_years([2022]) \
-            .on(date(month=6, day=3)) \
+            .on(date(Month.JUNE, 3)) \
             .with_flags("NV")
 
         """
@@ -119,7 +119,7 @@ class GB(Country):
         self.define_holiday() \
             .with_name("State Funeral of Queen Elizabeth II") \
             .in_years([2022]) \
-            .on(date(month=9, day=19)) \
+            .on(date(Month.SEPTEMBER, 19)) \
             .with_flags("NF")
 
     @staticmethod
@@ -130,8 +130,8 @@ class GB(Country):
         2022: Moved to June 2, because of Queen's Platinum Jubilee
         """
         if year == 2012:
-            return date(6, 4)(year)
+            return date(Month.JUNE, 4)(year)
         elif year == 2022:
-            return date(6, 2)(year)
+            return date(Month.JUNE, 2)(year)
         else:
-            return last("monday").of("may")(year)
+            return last(Weekday.MONDAY).of(Month.MAY)(year)

--- a/src/holidata/holidays/GR/__init__.py
+++ b/src/holidata/holidays/GR/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_ORTHODOX
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "GR",
@@ -18,37 +18,37 @@ class GR(Country):
 
         self.define_holiday() \
             .with_name("Πρωτοχρονιά") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Θεοφάνεια") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Ευαγγελισμός της Θεοτόκου και Εθνική Ημέρα Ανεξαρτησίας της Ελλάδας") \
-            .on(date(month=3, day=25)) \
+            .on(date(Month.MARCH, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Κοίμηση της Θεοτόκου") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Ημέρα του ΌΧΙ") \
-            .on(date(month=10, day=28)) \
+            .on(date(Month.OCTOBER, 28)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Χριστούγεννα") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Επόμενη ημέρα Χριστουγέννων") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -87,18 +87,18 @@ class GR(Country):
         """
         self.define_holiday() \
             .with_name("Πρωτομαγιά") \
-            .on(date(month=5, day=1)) \
-            .on_condition(date(month=5, day=1).is_not_equal_to(self.easter())) \
+            .on(date(Month.MAY, 1)) \
+            .on_condition(date(Month.MAY, 1).is_not_equal_to(self.easter())) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Πρωτομαγιά") \
-            .on(date(month=5, day=2)) \
-            .on_condition(date(month=4, day=30).is_equal_to(self.easter())) \
+            .on(date(Month.MAY, 2)) \
+            .on_condition(date(Month.APRIL, 30).is_equal_to(self.easter())) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Πρωτομαγιά") \
-            .on(date(month=5, day=3)) \
-            .on_condition(date(month=5, day=1).is_equal_to(self.easter())) \
+            .on(date(Month.MAY, 3)) \
+            .on_condition(date(Month.MAY, 1).is_equal_to(self.easter())) \
             .with_flags("NF")

--- a/src/holidata/holidays/HR/__init__.py
+++ b/src/holidata/holidays/HR/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "HR",
@@ -18,52 +18,52 @@ class HR(Country):
 
         self.define_holiday() \
             .with_name("Nova Godina") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Sveta tri kralja") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Praznik rada") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dan državnosti") \
-            .on(date(month=5, day=30)) \
+            .on(date(Month.MAY, 30)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dan antifašističke borbe") \
-            .on(date(month=6, day=22)) \
+            .on(date(Month.JUNE, 22)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja") \
-            .on(date(month=8, day=5)) \
+            .on(date(Month.AUGUST, 5)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Velika Gospa") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Dan svih svetih") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Božić") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Sveti Stjepan") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -84,5 +84,5 @@ class HR(Country):
         self.define_holiday() \
             .with_name("Dan sjećanja na žrtve Domovinskog rata i Dan sjećanja na žrtvu Vukovara i Škabrnje") \
             .since(2020) \
-            .on(date(month=11, day=18)) \
+            .on(date(Month.NOVEMBER, 18)) \
             .with_flags("NF")

--- a/src/holidata/holidays/HU/__init__.py
+++ b/src/holidata/holidays/HU/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "HU",
@@ -26,42 +26,42 @@ class HU(Country):
 
         self.define_holiday() \
             .with_name("Újév") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Az 1848-as forradalom ünnepe") \
-            .on(date(month=3, day=15)) \
+            .on(date(Month.MARCH, 15)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("A munka ünnepe") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Az államalapítás ünnepe") \
-            .on(date(month=8, day=20)) \
+            .on(date(Month.AUGUST, 20)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Az 1956-os forradalom ünnepe") \
-            .on(date(month=10, day=23)) \
+            .on(date(Month.OCTOBER, 23)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Mindenszentek") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Karácsony") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Karácsony") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -118,51 +118,51 @@ class HU(Country):
         """
         return {
             2015: [
-                (date(month=1, day=2), "2015-01-10 munkanap"),
-                (date(month=8, day=21), "2015-08-08 munkanap"),
-                (date(month=12, day=24), "2015-12-12 munkanap"),
+                (date(Month.JANUARY, 2), "2015-01-10 munkanap"),
+                (date(Month.AUGUST, 21), "2015-08-08 munkanap"),
+                (date(Month.DECEMBER, 24), "2015-12-12 munkanap"),
             ],
             2016: [
-                (date(month=3, day=14), "2016-03-05 munkanap"),
-                (date(month=10, day=31), "2016-10-15 munkanap"),
+                (date(Month.MARCH, 14), "2016-03-05 munkanap"),
+                (date(Month.OCTOBER, 31), "2016-10-15 munkanap"),
             ],
             2018: [
-                (date(month=3, day=16), "2018-03-10 munkanap"),
-                (date(month=4, day=30), "2018-04-21 munkanap"),
-                (date(month=10, day=22), "2018-10-13 munkanap"),
-                (date(month=11, day=2), "2018-11-10 munkanap"),
-                (date(month=12, day=24), "2018-12-01 munkanap"),
-                (date(month=12, day=31), "2018-12-15 munkanap"),
+                (date(Month.MARCH, 16), "2018-03-10 munkanap"),
+                (date(Month.APRIL, 30), "2018-04-21 munkanap"),
+                (date(Month.OCTOBER, 22), "2018-10-13 munkanap"),
+                (date(Month.NOVEMBER, 2), "2018-11-10 munkanap"),
+                (date(Month.DECEMBER, 24), "2018-12-01 munkanap"),
+                (date(Month.DECEMBER, 31), "2018-12-15 munkanap"),
             ],
             2019: [
-                (date(month=8, day=19), "2019-08-10 munkanap"),
-                (date(month=12, day=24), "2019-12-07 munkanap"),
-                (date(month=12, day=27), "2019-12-14 munkanap"),
+                (date(Month.AUGUST, 19), "2019-08-10 munkanap"),
+                (date(Month.DECEMBER, 24), "2019-12-07 munkanap"),
+                (date(Month.DECEMBER, 27), "2019-12-14 munkanap"),
             ],
             2020: [
-                (date(month=8, day=21), "2020-08-29 munkanap"),
-                (date(month=12, day=24), "2020-12-12 munkanap"),
+                (date(Month.AUGUST, 21), "2020-08-29 munkanap"),
+                (date(Month.DECEMBER, 24), "2020-12-12 munkanap"),
             ],
             2021: [
-                (date(month=12, day=24), "2021-12-11 munkanap")
+                (date(Month.DECEMBER, 24), "2021-12-11 munkanap")
             ],
             2022: [
-                (date(month=3, day=14), "2022-03-26 munkanap"),
-                (date(month=10, day=31), "2022-10-15 munkanap"),
+                (date(Month.MARCH, 14), "2022-03-26 munkanap"),
+                (date(Month.OCTOBER, 31), "2022-10-15 munkanap"),
             ],
             2024: [
-                (date(month=8, day=19), "2024-08-03 munkanap"),
-                (date(month=12, day=24), "2024-12-07 munkanap"),
-                (date(month=12, day=27), "2024-12-14 munkanap"),
+                (date(Month.AUGUST, 19), "2024-08-03 munkanap"),
+                (date(Month.DECEMBER, 24), "2024-12-07 munkanap"),
+                (date(Month.DECEMBER, 27), "2024-12-14 munkanap"),
             ],
             2025: [
-                (date(month=5, day=2), "2025-05-17 munkanap"),
-                (date(month=10, day=24), "2025-10-18 munkanap"),
-                (date(month=12, day=24), "2025-12-13 munkanap"),
+                (date(Month.MAY, 2), "2025-05-17 munkanap"),
+                (date(Month.OCTOBER, 24), "2025-10-18 munkanap"),
+                (date(Month.DECEMBER, 24), "2025-12-13 munkanap"),
             ],
             2026: [
-                (date(month=1, day=2), "2026-01-10 munkanap"),
-                (date(month=8, day=21), "2026-08-08 munkanap"),
-                (date(month=12, day=24), "2026-12-12 munkanap"),
+                (date(Month.JANUARY, 2), "2026-01-10 munkanap"),
+                (date(Month.AUGUST, 21), "2026-08-08 munkanap"),
+                (date(Month.DECEMBER, 24), "2026-12-12 munkanap"),
             ]
         }

--- a/src/holidata/holidays/IS/__init__.py
+++ b/src/holidata/holidays/IS/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, date
+from holidata.utils import day, first, date, Weekday, Month
 
 __all__ = [
     "IS",
@@ -18,27 +18,27 @@ class IS(Country):
 
         self.define_holiday() \
             .with_name("Nýársdagur") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Verkalýðsdagurinn") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Þjóðhátíðardagurinn") \
-            .on(date(month=6, day=17)) \
+            .on(date(Month.JUNE, 17)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Jóladagur") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Annar dagur jóla") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -78,12 +78,12 @@ class IS(Country):
 
         self.define_holiday() \
             .with_name("Frídagur verslunarmanna") \
-            .on(first("monday").of("august")) \
+            .on(first(Weekday.MONDAY).of(Month.AUGUST)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Sumardagurinn fyrsti") \
-            .on(first("thursday").after(date(month=4, day=18))) \
+            .on(first(Weekday.THURSDAY).after(date(Month.APRIL, 18))) \
             .with_flags("NV")
 
         """ 
@@ -92,12 +92,12 @@ class IS(Country):
         """
         self.define_holiday() \
             .with_name("Aðfangadagur jóla") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF") \
             .annotated_with("Holiday from 13:00")
 
         self.define_holiday() \
             .with_name("Gamlársdagur") \
-            .on(date(month=12, day=31)) \
+            .on(date(Month.DECEMBER, 31)) \
             .with_flags("NF") \
             .annotated_with("Holiday from 13:00")

--- a/src/holidata/holidays/IT/__init__.py
+++ b/src/holidata/holidays/IT/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, date
+from holidata.utils import day, first, date, Weekday, Month
 
 __all__ = [
     "IT",
@@ -28,69 +28,69 @@ class IT(Country):
 
         self.define_holiday() \
             .with_name("Capodanno") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Epifania") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Festa della liberazione") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Festa del lavoro") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Festa della repubblica") \
-            .on(date(month=6, day=2)) \
+            .on(date(Month.JUNE, 2)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Santi Apostoli Pietro e Paolo") \
-            .on(date(month=6, day=29)) \
+            .on(date(Month.JUNE, 29)) \
             .with_flags("NRF") \
             .annotated_with("Solo per il comune di Roma")
 
         self.define_holiday() \
             .with_name("Assunzione (ferragosto)") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Festa nazionale di San Francesco d'Assisi, patrono d'Italia") \
             .since(2026) \
-            .on(date(month=10, day=4)) \
+            .on(date(Month.OCTOBER, 4)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Ognissanti") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Unità nazionale") \
-            .on(first("sunday").of("november")) \
+            .on(first(Weekday.SUNDAY).of(Month.NOVEMBER)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Immacolata concezione") \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Natale") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("S.to Stefano") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/NL/__init__.py
+++ b/src/holidata/holidays/NL/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Weekday, Month
 
 __all__ = [
     "NL",
@@ -18,32 +18,32 @@ class NL(Country):
 
         self.define_holiday() \
             .with_name("Nieuwjaarsdag") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dodenherdenking") \
-            .on(date(month=5, day=4)) \
+            .on(date(Month.MAY, 4)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Bevrijdingsdag") \
-            .on(date(month=5, day=5)) \
+            .on(date(Month.MAY, 5)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Sinterklaas") \
-            .on(date(month=12, day=5)) \
+            .on(date(Month.DECEMBER, 5)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Eerste Kerstdag") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Tweede Kerstdag") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -83,15 +83,15 @@ class NL(Country):
         self.define_holiday() \
             .with_name("Koninginnedag") \
             .until(2013) \
-            .on(date(month=4, day=29)) \
-            .on_condition(date(month=4, day=30).is_a("sunday")) \
+            .on(date(Month.APRIL, 29)) \
+            .on_condition(date(Month.APRIL, 30).is_a(Weekday.SUNDAY)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Koninginnedag") \
             .until(2013) \
-            .on(date(month=4, day=30)) \
-            .on_condition(date(month=4, day=30).is_not_a("sunday")) \
+            .on(date(Month.APRIL, 30)) \
+            .on_condition(date(Month.APRIL, 30).is_not_a(Weekday.SUNDAY)) \
             .with_flags("NV")
 
         """
@@ -101,15 +101,15 @@ class NL(Country):
         self.define_holiday() \
             .with_name("Koningsdag") \
             .since(2014) \
-            .on(date(month=4, day=26)) \
-            .on_condition(date(month=4, day=27).is_a("sunday")) \
+            .on(date(Month.APRIL, 26)) \
+            .on_condition(date(Month.APRIL, 27).is_a(Weekday.SUNDAY)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Koningsdag") \
             .since(2014) \
-            .on(date(month=4, day=27)) \
-            .on_condition(date(month=4, day=27).is_not_a("sunday")) \
+            .on(date(Month.APRIL, 27)) \
+            .on_condition(date(Month.APRIL, 27).is_not_a(Weekday.SUNDAY)) \
             .with_flags("NV")
 
         """
@@ -118,12 +118,12 @@ class NL(Country):
         """
         self.define_holiday() \
             .with_name("Koninkrijksdag") \
-            .on(date(month=12, day=15)) \
-            .on_condition(date(month=12, day=15).is_not_a("sunday")) \
+            .on(date(Month.DECEMBER, 15)) \
+            .on_condition(date(Month.DECEMBER, 15).is_not_a(Weekday.SUNDAY)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Koninkrijksdag") \
-            .on(date(month=12, day=16)) \
-            .on_condition(date(month=12, day=15).is_a("sunday")) \
+            .on(date(Month.DECEMBER, 16)) \
+            .on_condition(date(Month.DECEMBER, 15).is_a(Weekday.SUNDAY)) \
             .with_flags("NV")

--- a/src/holidata/holidays/NO/__init__.py
+++ b/src/holidata/holidays/NO/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "NO",
@@ -18,42 +18,42 @@ class NO(Country):
 
         self.define_holiday() \
             .with_name("Nyttårsdag") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Offentlig Høytidsdag") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Frigjøringsdag 1945") \
-            .on(date(month=5, day=8)) \
+            .on(date(Month.MAY, 8)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Grunnlovsdag") \
-            .on(date(month=5, day=17)) \
+            .on(date(Month.MAY, 17)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Julaften") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Juledag") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Juledag") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Nyttårsaften") \
-            .on(date(month=12, day=31)) \
+            .on(date(Month.DECEMBER, 31)) \
             .with_flags("NF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/NZ/__init__.py
+++ b/src/holidata/holidays/NZ/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, fourth, date
+from holidata.utils import day, first, fourth, date, Weekday, Month
 
 __all__ = [
     "NZ",
@@ -18,90 +18,90 @@ class NZ(Country):
 
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("New Year's Day (observed)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("NV") \
-            .on_condition(date(month=1, day=1).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         self.define_holiday() \
             .with_name("Day after New Year's Day") \
-            .on(date(month=1, day=2)) \
-            .on_condition(date(month=1, day=1).is_none_of(["friday", "saturday", "sunday"])) \
+            .on(date(Month.JANUARY, 2)) \
+            .on_condition(date(Month.JANUARY, 1).is_none_of([Weekday.FRIDAY, Weekday.SATURDAY, Weekday.SUNDAY])) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Day after New Year's Day") \
-            .on(date(month=1, day=3)) \
-            .on_condition(date(month=1, day=1).is_a("sunday")) \
+            .on(date(Month.JANUARY, 3)) \
+            .on_condition(date(Month.JANUARY, 1).is_a(Weekday.SUNDAY)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Day after New Year's Day") \
-            .on(date(month=1, day=4)) \
-            .on_condition(date(month=1, day=1).is_one_of(["friday", "saturday"])) \
+            .on(date(Month.JANUARY, 4)) \
+            .on_condition(date(Month.JANUARY, 1).is_one_of([Weekday.FRIDAY, Weekday.SATURDAY])) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Waitangi Day") \
-            .on(date(month=2, day=6)) \
+            .on(date(Month.FEBRUARY, 6)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Waitangi Day (observed)") \
             .since(2017) \
-            .on(first("monday").after(date(month=2, day=6))) \
+            .on(first(Weekday.MONDAY).after(date(Month.FEBRUARY, 6))) \
             .with_flags("NV") \
-            .on_condition(date(month=2, day=6).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.FEBRUARY, 6).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         self.define_holiday() \
             .with_name("ANZAC Day") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("ANZAC Day (observed)") \
             .since(2016) \
-            .on(first("monday").after(date(month=4, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.APRIL, 25))) \
             .with_flags("NV") \
-            .on_condition(date(month=4, day=25).is_one_of(["saturday", "sunday"]))
+            .on_condition(date(Month.APRIL, 25).is_one_of([Weekday.SATURDAY, Weekday.SUNDAY]))
 
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=25))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("NV") \
-            .on_condition(date(month=12, day=25).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Christmas Day (observed)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("NV") \
-            .on_condition(date(month=12, day=25).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("tuesday").after(date(month=12, day=26))) \
+            .on(first(Weekday.TUESDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("NV") \
-            .on_condition(date(month=12, day=26).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Boxing Day (observed)") \
-            .on(first("monday").after(date(month=12, day=26))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 26))) \
             .with_flags("NV") \
-            .on_condition(date(month=12, day=26).is_a("saturday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SATURDAY))
 
         self.define_holiday() \
             .with_name("Good Friday") \
@@ -115,10 +115,10 @@ class NZ(Country):
 
         self.define_holiday() \
             .with_name("Queen's Birthday") \
-            .on(first("monday").of("june")) \
+            .on(first(Weekday.MONDAY).of(Month.JUNE)) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(fourth("monday").of("october")) \
+            .on(fourth(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("NV")

--- a/src/holidata/holidays/PL/__init__.py
+++ b/src/holidata/holidays/PL/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "PL",
@@ -23,53 +23,53 @@ class PL(Country):
 
         self.define_holiday() \
             .with_name("Nowy Rok") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Trzech Króli") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Święto Pracy") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Święto Konstytucji Trzeciego Maja") \
-            .on(date(month=5, day=3)) \
+            .on(date(Month.MAY, 3)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Wniebowzięcie Najświętszej Maryi Panny") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Wszystkich Świętych") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Narodowe Święto Niepodległości") \
-            .on(date(month=11, day=11)) \
+            .on(date(Month.NOVEMBER, 11)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Wigilia") \
             .since(2025) \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Boże Narodzenie (pierwszy dzień)") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Boże Narodzenie (drugi dzień)") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/PT/__init__.py
+++ b/src/holidata/holidays/PT/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "PT",
@@ -18,52 +18,52 @@ class PT(Country):
 
         self.define_holiday() \
             .with_name("Ano Novo") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dia da Liberdade") \
-            .on(date(month=4, day=25)) \
+            .on(date(Month.APRIL, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dia do Trabalhador") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dia de Portugal") \
-            .on(date(month=6, day=10)) \
+            .on(date(Month.JUNE, 10)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Assunção de Nossa Senhora") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Implantação da República") \
-            .on(date(month=10, day=5)) \
+            .on(date(Month.OCTOBER, 5)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dia de Todos os Santos") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Restauração da Independência") \
-            .on(date(month=12, day=1)) \
+            .on(date(Month.DECEMBER, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Imaculada Conceição") \
-            .on(date(month=12, day=8)) \
+            .on(date(Month.DECEMBER, 8)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Natal") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/RU/__init__.py
+++ b/src/holidata/holidays/RU/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_ORTHODOX
 
 from holidata.holiday import Country
-from holidata.utils import date
+from holidata.utils import date, Month
 
 __all__ = [
     "RU",
@@ -18,42 +18,42 @@ class RU(Country):
 
         self.define_holiday() \
             .with_name("Новый Год") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Рождество Христово") \
-            .on(date(month=1, day=7)) \
+            .on(date(Month.JANUARY, 7)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("День защитника Отечества") \
-            .on(date(month=2, day=23)) \
+            .on(date(Month.FEBRUARY, 23)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Международный женский день") \
-            .on(date(month=3, day=8)) \
+            .on(date(Month.MARCH, 8)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Праздник весны и труда") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("День Победы") \
-            .on(date(month=5, day=9)) \
+            .on(date(Month.MAY, 9)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("День России") \
-            .on(date(month=6, day=12)) \
+            .on(date(Month.JUNE, 12)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("День народного единства") \
-            .on(date(month=11, day=4)) \
+            .on(date(Month.NOVEMBER, 4)) \
             .with_flags("NF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/SE/__init__.py
+++ b/src/holidata/holidays/SE/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, first, date
+from holidata.utils import day, first, date, Weekday, Month
 
 __all__ = [
     "SE",
@@ -18,42 +18,42 @@ class SE(Country):
 
         self.define_holiday() \
             .with_name("Nyårsdagen") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Trettondedag jul") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Första maj") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Nationaldagen") \
-            .on(date(month=6, day=6)) \
+            .on(date(Month.JUNE, 6)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Julafton") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Juldagen") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Annandag jul") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Nyårsafton") \
-            .on(date(month=12, day=31)) \
+            .on(date(Month.DECEMBER, 31)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -83,15 +83,15 @@ class SE(Country):
 
         self.define_holiday() \
             .with_name("Midsommarafton") \
-            .on(day(1).before(first("saturday").after(date(month=6, day=19)))) \
+            .on(day(1).before(first(Weekday.SATURDAY).after(date(Month.JUNE, 19)))) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Midsommardagen") \
-            .on(first("saturday").after(date(month=6, day=19))) \
+            .on(first(Weekday.SATURDAY).after(date(Month.JUNE, 19))) \
             .with_flags("NV")
 
         self.define_holiday() \
             .with_name("Alla helgons dag") \
-            .on(first("saturday").after(date(month=10, day=30))) \
+            .on(first(Weekday.SATURDAY).after(date(Month.OCTOBER, 30))) \
             .with_flags("NRV")

--- a/src/holidata/holidays/SG/__init__.py
+++ b/src/holidata/holidays/SG/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date, first
+from holidata.utils import day, date, first, Month, Weekday
 
 __all__ = [
     "SG",
@@ -28,14 +28,14 @@ class SG(Country):
 
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF") \
 
         self.define_holiday() \
             .with_name("New Year's Day (in lieu)") \
-            .on(first("monday").after(date(month=1, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.JANUARY, 1))) \
             .with_flags("NF") \
-            .on_condition(date(month=1, day=1).is_a("sunday"))
+            .on_condition(date(Month.JANUARY, 1).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Chinese New Year") \
@@ -59,14 +59,14 @@ class SG(Country):
 
         self.define_holiday() \
             .with_name("Labour Day") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF") \
 
         self.define_holiday() \
             .with_name("Labour Day (in lieu)") \
-            .on(first("monday").after(date(month=5, day=1))) \
+            .on(first(Weekday.MONDAY).after(date(Month.MAY, 1))) \
             .with_flags("NF") \
-            .on_condition(date(month=5, day=1).is_a("sunday"))
+            .on_condition(date(Month.MAY, 1).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Hari Raya Puasa") \
@@ -100,14 +100,14 @@ class SG(Country):
 
         self.define_holiday() \
             .with_name("National Day") \
-            .on(date(month=8, day=9)) \
+            .on(date(Month.AUGUST, 9)) \
             .with_flags("NF") \
 
         self.define_holiday() \
             .with_name("National Day (in lieu)") \
-            .on(first("monday").after(date(month=8, day=9))) \
+            .on(first(Weekday.MONDAY).after(date(Month.AUGUST, 9))) \
             .with_flags("NF") \
-            .on_condition(date(month=8, day=9).is_a("sunday"))
+            .on_condition(date(Month.AUGUST, 9).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Deepavali") \
@@ -121,14 +121,14 @@ class SG(Country):
 
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF") \
 
         self.define_holiday() \
             .with_name("Christmas Day (in lieu)") \
-            .on(first("monday").after(date(month=12, day=25))) \
+            .on(first(Weekday.MONDAY).after(date(Month.DECEMBER, 25))) \
             .with_flags("NRF") \
-            .on_condition(date(month=12, day=25).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SUNDAY))
 
         """
         General Election day
@@ -154,26 +154,26 @@ class SG(Country):
         """
         self.define_holiday() \
             .with_name("SG50 Public Holiday") \
-            .on(date(month=8, day=7)) \
+            .on(date(Month.AUGUST, 7)) \
             .in_years([2015]) \
             .with_flags("NF")
 
     @staticmethod
     def date_of_general_election(year):
         dates = {
-            2011: date(month=5, day=7),
-            2015: date(month=9, day=11),
-            2020: date(month=7, day=10),
-            2025: date(month=5, day=3),
+            2011: date(Month.MAY, 7),
+            2015: date(Month.SEPTEMBER, 11),
+            2020: date(Month.JULY, 10),
+            2025: date(Month.MAY, 3),
         }
         return dates.get(year)(year) if year in dates else None
 
     @staticmethod
     def date_of_presidential_election(year):
         dates = {
-            2011: date(month=8, day=27),
-            2017: date(month=9, day=13),
-            2023: date(month=9, day=1),
+            2011: date(Month.AUGUST, 27),
+            2017: date(Month.SEPTEMBER, 13),
+            2023: date(Month.SEPTEMBER, 1),
         }
         return dates.get(year)(year) if year in dates else None
 
@@ -181,22 +181,22 @@ class SG(Country):
     def chinese_new_year(year):
         """Return the date of Chinese New Year for the given year."""
         dates = {
-            2011: date(2, 3),
-            2012: date(1, 23),
-            2013: date(2, 10),
-            2014: date(1, 31),
-            2015: date(2, 19),
-            2016: date(2, 8),
-            2017: date(1, 28),
-            2018: date(2, 16),
-            2019: date(2, 5),
-            2020: date(1, 25),
-            2021: date(2, 12),
-            2022: date(2, 1),
-            2023: date(1, 22),
-            2024: date(2, 10),
-            2025: date(1, 29),
-            2026: date(2, 17)
+            2011: date(Month.FEBRUARY, 3),
+            2012: date(Month.JANUARY, 23),
+            2013: date(Month.FEBRUARY, 10),
+            2014: date(Month.JANUARY, 31),
+            2015: date(Month.FEBRUARY, 19),
+            2016: date(Month.FEBRUARY, 8),
+            2017: date(Month.JANUARY, 28),
+            2018: date(Month.FEBRUARY, 16),
+            2019: date(Month.FEBRUARY, 5),
+            2020: date(Month.JANUARY, 25),
+            2021: date(Month.FEBRUARY, 12),
+            2022: date(Month.FEBRUARY, 1),
+            2023: date(Month.JANUARY, 22),
+            2024: date(Month.FEBRUARY, 10),
+            2025: date(Month.JANUARY, 29),
+            2026: date(Month.FEBRUARY, 17)
         }
         return dates.get(year)(year) if year in dates else None
 
@@ -209,128 +209,128 @@ class SG(Country):
     @staticmethod
     def chinese_new_year_in_lieu(year):
         holiday_date = SG.chinese_new_year(year)
-        if holiday_date is not None and holiday_date.weekday() == "saturday":
-            return holiday_date.shift_to_weekday("monday")
-        elif holiday_date is not None and holiday_date.weekday() == "sunday":
-            return holiday_date.shift_to_weekday("tuesday")
+        if holiday_date is not None and holiday_date.weekday() == Weekday.SATURDAY:
+            return holiday_date.shift_to_weekday(Weekday.MONDAY)
+        elif holiday_date is not None and holiday_date.weekday() == Weekday.SUNDAY:
+            return holiday_date.shift_to_weekday(Weekday.TUESDAY)
         return None
 
     @staticmethod
     def hari_raya_puasa(year):
         """Return the date of Hari Raya Puasa for the given year."""
         dates = {
-            2011: date(8, 30),
-            2012: date(8, 19),
-            2013: date(8, 8),
-            2014: date(7, 28),
-            2015: date(7, 17),
-            2016: date(7, 6),
-            2017: date(6, 25),
-            2018: date(6, 15),
-            2019: date(6, 5),
-            2020: date(5, 24),
-            2021: date(5, 13),
-            2022: date(5, 3),
-            2023: date(4, 22),
-            2024: date(4, 10),
-            2025: date(3, 31),
-            2026: date(3, 21)
+            2011: date(Month.AUGUST, 30),
+            2012: date(Month.AUGUST, 19),
+            2013: date(Month.AUGUST, 8),
+            2014: date(Month.JULY, 28),
+            2015: date(Month.JULY, 17),
+            2016: date(Month.JULY, 6),
+            2017: date(Month.JUNE, 25),
+            2018: date(Month.JUNE, 15),
+            2019: date(Month.JUNE, 5),
+            2020: date(Month.MAY, 24),
+            2021: date(Month.MAY, 13),
+            2022: date(Month.MAY, 3),
+            2023: date(Month.APRIL, 22),
+            2024: date(Month.APRIL, 10),
+            2025: date(Month.MARCH, 31),
+            2026: date(Month.MARCH, 21)
         }
         return dates.get(year)(year) if year in dates else None
 
     @staticmethod
     def hari_raya_puasa_in_lieu(year):
         holiday_date = SG.hari_raya_puasa(year)
-        if holiday_date is not None and holiday_date.weekday() == "sunday":
-            return holiday_date.shift_to_weekday("monday")
+        if holiday_date is not None and holiday_date.weekday() == Weekday.SUNDAY:
+            return holiday_date.shift_to_weekday(Weekday.MONDAY)
         return None
 
     @staticmethod
     def vesak_day(year):
         """Return the date of Vesak Day for the given year."""
         dates = {
-            2011: date(5, 17),
-            2012: date(5, 5),
-            2013: date(5, 24),
-            2014: date(5, 13),
-            2015: date(6, 1),
-            2016: date(5, 21),
-            2017: date(5, 10),
-            2018: date(5, 29),
-            2019: date(5, 19),
-            2020: date(5, 7),
-            2021: date(5, 26),
-            2022: date(5, 15),
-            2023: date(6, 2),
-            2024: date(5, 22),
-            2025: date(5, 12),
-            2026: date(5, 31)
+            2011: date(Month.MAY, 17),
+            2012: date(Month.MAY, 5),
+            2013: date(Month.MAY, 24),
+            2014: date(Month.MAY, 13),
+            2015: date(Month.JUNE, 1),
+            2016: date(Month.MAY, 21),
+            2017: date(Month.MAY, 10),
+            2018: date(Month.MAY, 29),
+            2019: date(Month.MAY, 19),
+            2020: date(Month.MAY, 7),
+            2021: date(Month.MAY, 26),
+            2022: date(Month.MAY, 15),
+            2023: date(Month.JUNE, 2),
+            2024: date(Month.MAY, 22),
+            2025: date(Month.MAY, 12),
+            2026: date(Month.MAY, 31)
         }
         return dates.get(year)(year) if year in dates else None
 
     @staticmethod
     def vesak_day_in_lieu(year):
         holiday_date = SG.vesak_day(year)
-        if holiday_date is not None and holiday_date.weekday() == "sunday":
-            return holiday_date.shift_to_weekday("monday")
+        if holiday_date is not None and holiday_date.weekday() == Weekday.SUNDAY:
+            return holiday_date.shift_to_weekday(Weekday.MONDAY)
         return None
 
     @staticmethod
     def hari_raya_haji(year):
         """Return the date of Hari Raya Haji for the given year."""
         dates = {
-            2011: date(11, 6),
-            2012: date(10, 26),
-            2013: date(10, 15),
-            2014: date(10, 5),
-            2015: date(9, 24),
-            2016: date(9, 12),
-            2017: date(9, 1),
-            2018: date(8, 22),
-            2019: date(8, 11),
-            2020: date(7, 31),
-            2021: date(7, 20),
-            2022: date(7, 10),
-            2023: date(6, 29),
-            2024: date(6, 17),
-            2025: date(6, 7),
-            2026: date(5, 27)
+            2011: date(Month.NOVEMBER, 6),
+            2012: date(Month.OCTOBER, 26),
+            2013: date(Month.OCTOBER, 15),
+            2014: date(Month.OCTOBER, 5),
+            2015: date(Month.SEPTEMBER, 24),
+            2016: date(Month.SEPTEMBER, 12),
+            2017: date(Month.SEPTEMBER, 1),
+            2018: date(Month.AUGUST, 22),
+            2019: date(Month.AUGUST, 11),
+            2020: date(Month.JULY, 31),
+            2021: date(Month.JULY, 20),
+            2022: date(Month.JULY, 10),
+            2023: date(Month.JUNE, 29),
+            2024: date(Month.JUNE, 17),
+            2025: date(Month.JUNE, 7),
+            2026: date(Month.MAY, 27)
         }
         return dates.get(year)(year) if year in dates else None
 
     @staticmethod
     def hari_raya_haji_in_lieu(year):
         holiday_date = SG.hari_raya_haji(year)
-        if holiday_date is not None and holiday_date.weekday() == "sunday":
-            return holiday_date.shift_to_weekday("monday")
+        if holiday_date is not None and holiday_date.weekday() == Weekday.SUNDAY:
+            return holiday_date.shift_to_weekday(Weekday.MONDAY)
         return None
 
     @staticmethod
     def deepavali(year):
         """Return the date of Deepavali for the given year."""
         dates = {
-            2011: date(10, 26),
-            2012: date(11, 13),
-            2013: date(11, 2),
-            2014: date(10, 22),
-            2015: date(11, 10),
-            2016: date(10, 29),
-            2017: date(10, 18),
-            2018: date(11, 6),
-            2019: date(10, 27),
-            2020: date(11, 14),
-            2021: date(11, 4),
-            2022: date(10, 24),
-            2023: date(11, 12),
-            2024: date(10, 31),
-            2025: date(10, 20),
-            2026: date(11, 8)
+            2011: date(Month.OCTOBER, 26),
+            2012: date(Month.NOVEMBER, 13),
+            2013: date(Month.NOVEMBER, 2),
+            2014: date(Month.OCTOBER, 22),
+            2015: date(Month.NOVEMBER, 10),
+            2016: date(Month.OCTOBER, 29),
+            2017: date(Month.OCTOBER, 18),
+            2018: date(Month.NOVEMBER, 6),
+            2019: date(Month.OCTOBER, 27),
+            2020: date(Month.NOVEMBER, 14),
+            2021: date(Month.NOVEMBER, 4),
+            2022: date(Month.OCTOBER, 24),
+            2023: date(Month.NOVEMBER, 12),
+            2024: date(Month.OCTOBER, 31),
+            2025: date(Month.OCTOBER, 20),
+            2026: date(Month.NOVEMBER, 8)
         }
         return dates.get(year)(year) if year in dates else None
 
     @staticmethod
     def deepavali_in_lieu(year):
         holiday_date = SG.deepavali(year)
-        if holiday_date is not None and holiday_date.weekday() == "sunday":
-            return holiday_date.shift_to_weekday("monday")
+        if holiday_date is not None and holiday_date.weekday() == Weekday.SUNDAY:
+            return holiday_date.shift_to_weekday(Weekday.MONDAY)
         return None

--- a/src/holidata/holidays/SI/__init__.py
+++ b/src/holidata/holidays/SI/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "SI",
@@ -18,7 +18,7 @@ class SI(Country):
 
         self.define_holiday() \
             .with_name("Novo leto") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         """
@@ -29,58 +29,58 @@ class SI(Country):
         """
         self.define_holiday() \
             .with_name("Novo leto") \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .except_for([2013, 2014, 2015, 2016]) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Prešernov dan") \
-            .on(date(month=2, day=8)) \
+            .on(date(Month.FEBRUARY, 8)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dan upora proti okupatorju") \
-            .on(date(month=4, day=27)) \
+            .on(date(Month.APRIL, 27)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Praznik dela") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Praznik dela") \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dan državnosti") \
-            .on(date(month=6, day=25)) \
+            .on(date(Month.JUNE, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Marijino vnebovzetje") \
-            .on(date(month=8, day=15)) \
+            .on(date(Month.AUGUST, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Dan reformacije") \
-            .on(date(month=10, day=31)) \
+            .on(date(Month.OCTOBER, 31)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Dan spomina na mrtve") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Božič") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Dan samostojnosti in enotnosti") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/SK/__init__.py
+++ b/src/holidata/holidays/SK/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Month
 
 __all__ = [
     "SK",
@@ -18,67 +18,67 @@ class SK(Country):
 
         self.define_holiday() \
             .with_name("Deň vzniku Slovenskej republiky") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Zjavenie Pána / Traja králi") \
-            .on(date(month=1, day=6)) \
+            .on(date(Month.JANUARY, 6)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Sviatok práce") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Deň víťazstva nad fašizmom") \
-            .on(date(month=5, day=8)) \
+            .on(date(Month.MAY, 8)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Sviatok svätého Cyrila a Metoda") \
-            .on(date(month=7, day=5)) \
+            .on(date(Month.JULY, 5)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Výročie SNP") \
-            .on(date(month=8, day=29)) \
+            .on(date(Month.AUGUST, 29)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Deň Ústavy Slovenskej republiky") \
-            .on(date(month=9, day=1)) \
+            .on(date(Month.SEPTEMBER, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Sedembolestná Panna Mária") \
-            .on(date(month=9, day=15)) \
+            .on(date(Month.SEPTEMBER, 15)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Sviatok všetkých svätých") \
-            .on(date(month=11, day=1)) \
+            .on(date(Month.NOVEMBER, 1)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Deň boja za slobodu a demokraciu") \
-            .on(date(month=11, day=17)) \
+            .on(date(Month.NOVEMBER, 17)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Štedrý deň") \
-            .on(date(month=12, day=24)) \
+            .on(date(Month.DECEMBER, 24)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Prvý sviatok vianočný") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
             .with_name("Druhý sviatok vianočný") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NRF")
 
         self.define_holiday() \

--- a/src/holidata/holidays/TR/__init__.py
+++ b/src/holidata/holidays/TR/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import date
+from holidata.utils import date, Month
 
 __all__ = [
     "TR",
@@ -24,37 +24,37 @@ class TR(Country):
 
         self.define_holiday() \
             .with_name("Yılbaşı") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Ulusal Egemenlik ve Çocuk Bayramı") \
-            .on(date(month=4, day=23)) \
+            .on(date(Month.APRIL, 23)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Emek ve Dayanışma Günü") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Atatürk'ü Anma, Gençlik ve Spor Bayramı") \
-            .on(date(month=5, day=19)) \
+            .on(date(Month.MAY, 19)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Zafer Bayramı") \
-            .on(date(month=8, day=30)) \
+            .on(date(Month.AUGUST, 30)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Cumhuriyet Bayramı") \
-            .on(date(month=10, day=29)) \
+            .on(date(Month.OCTOBER, 29)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Demokrasi ve Milli Birlik Günü") \
-            .on(date(month=7, day=15)) \
+            .on(date(Month.JULY, 15)) \
             .since(2017) \
             .with_flags("NF")
 
@@ -95,23 +95,23 @@ class TR(Country):
     @staticmethod
     def __ramazan_bayrami_reference(year):
         dates = {
-            2011: date(8, 29),
-            2012: date(8, 18),
-            2013: date(8, 7),
-            2014: date(7, 27),
-            2015: date(7, 16),
-            2016: date(7, 4),
-            2017: date(6, 24),
-            2018: date(6, 14),
-            2019: date(6, 4),
-            2020: date(5, 23),
-            2021: date(5, 12),
-            2022: date(5, 1),
-            2023: date(4, 20),
-            2024: date(4, 9),
-            2025: date(3, 29),
-            2026: date(3, 19),
-            2027: date(3, 8),
+            2011: date(Month.AUGUST, 29),
+            2012: date(Month.AUGUST, 18),
+            2013: date(Month.AUGUST, 7),
+            2014: date(Month.JULY, 27),
+            2015: date(Month.JULY, 16),
+            2016: date(Month.JULY, 4),
+            2017: date(Month.JUNE, 24),
+            2018: date(Month.JUNE, 14),
+            2019: date(Month.JUNE, 4),
+            2020: date(Month.MAY, 23),
+            2021: date(Month.MAY, 12),
+            2022: date(Month.MAY, 1),
+            2023: date(Month.APRIL, 20),
+            2024: date(Month.APRIL, 9),
+            2025: date(Month.MARCH, 29),
+            2026: date(Month.MARCH, 19),
+            2027: date(Month.MARCH, 8),
         }
 
         return dates.get(year)(year) if year in dates else None
@@ -119,23 +119,23 @@ class TR(Country):
     @staticmethod
     def __kurban_bayrami_reference(year):
         dates = {
-            2011: date(11, 5),
-            2012: date(10, 24),
-            2013: date(10, 14),
-            2014: date(10, 3),
-            2015: date(9, 23),
-            2016: date(9, 11),
-            2017: date(8, 31),
-            2018: date(8, 20),
-            2019: date(8, 10),
-            2020: date(7, 30),
-            2021: date(7, 19),
-            2022: date(7, 8),
-            2023: date(6, 27),
-            2024: date(6, 15),
-            2025: date(6, 5),
-            2026: date(5, 26),
-            2027: date(5, 15),
+            2011: date(Month.NOVEMBER, 5),
+            2012: date(Month.OCTOBER, 24),
+            2013: date(Month.OCTOBER, 14),
+            2014: date(Month.OCTOBER, 3),
+            2015: date(Month.SEPTEMBER, 23),
+            2016: date(Month.SEPTEMBER, 11),
+            2017: date(Month.AUGUST, 31),
+            2018: date(Month.AUGUST, 20),
+            2019: date(Month.AUGUST, 10),
+            2020: date(Month.JULY, 30),
+            2021: date(Month.JULY, 19),
+            2022: date(Month.JULY, 8),
+            2023: date(Month.JUNE, 27),
+            2024: date(Month.JUNE, 15),
+            2025: date(Month.JUNE, 5),
+            2026: date(Month.MAY, 26),
+            2027: date(Month.MAY, 15),
         }
 
         return dates.get(year)(year) if year in dates else None

--- a/src/holidata/holidays/US/__init__.py
+++ b/src/holidata/holidays/US/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import first, second, third, fourth, last, day, date
+from holidata.utils import first, second, third, fourth, last, day, date, Weekday, Month
 
 __all__ = [
     "US",
@@ -22,7 +22,7 @@ class US(Country):
                 "en": "New Year's Day",
                 "es": "Año Neuvo",
             }) \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -30,8 +30,8 @@ class US(Country):
                 "en": "New Year's Day (in lieu of)",
                 "es": "Año Neuvo (en lugar de)",
             }) \
-            .on(date(month=12, day=31)) \
-            .on_condition(date(month=12, day=31).is_a("friday")) \
+            .on(date(Month.DECEMBER, 31)) \
+            .on_condition(date(Month.DECEMBER, 31).is_a(Weekday.FRIDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -39,8 +39,8 @@ class US(Country):
                 "en": "New Year's Day (in lieu of)",
                 "es": "Año Neuvo (en lugar de)",
             }) \
-            .on(date(month=1, day=2)) \
-            .on_condition(date(month=1, day=1).is_a("sunday")) \
+            .on(date(Month.JANUARY, 2)) \
+            .on_condition(date(Month.JANUARY, 1).is_a(Weekday.SUNDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -49,7 +49,7 @@ class US(Country):
                 "es": "Juneteenth – Día de la Emancipación",
             }) \
             .since(2021) \
-            .on(date(month=6, day=19)) \
+            .on(date(Month.JUNE, 19)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -58,8 +58,8 @@ class US(Country):
                 "es": "Juneteenth – Día de la Emancipación (en lugar de)",
             }) \
             .since(2021) \
-            .on(date(month=6, day=18)) \
-            .on_condition(date(month=6, day=19).is_a("saturday")) \
+            .on(date(Month.JUNE, 18)) \
+            .on_condition(date(Month.JUNE, 19).is_a(Weekday.SATURDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -68,8 +68,8 @@ class US(Country):
                 "es": "Juneteenth – Día de la Emancipación (en lugar de)",
             }) \
             .since(2021) \
-            .on(date(month=6, day=20)) \
-            .on_condition(date(month=6, day=19).is_a("sunday")) \
+            .on(date(Month.JUNE, 20)) \
+            .on_condition(date(Month.JUNE, 19).is_a(Weekday.SUNDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -77,7 +77,7 @@ class US(Country):
                 "en": "Independence Day",
                 "es": "Día de la Independiencia",
             }) \
-            .on(date(month=7, day=4)) \
+            .on(date(Month.JULY, 4)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -85,8 +85,8 @@ class US(Country):
                 "en": "Independence Day (in lieu of)",
                 "es": "Día de la Independiencia (en lugar de)",
             }) \
-            .on(date(month=7, day=3)) \
-            .on_condition(date(month=7, day=4).is_a("saturday")) \
+            .on(date(Month.JULY, 3)) \
+            .on_condition(date(Month.JULY, 4).is_a(Weekday.SATURDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -94,8 +94,8 @@ class US(Country):
                 "en": "Independence Day (in lieu of)",
                 "es": "Día de la Independiencia (en lugar de)",
             }) \
-            .on(date(month=7, day=5)) \
-            .on_condition(date(month=7, day=4).is_a("sunday")) \
+            .on(date(Month.JULY, 5)) \
+            .on_condition(date(Month.JULY, 4).is_a(Weekday.SUNDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -103,7 +103,7 @@ class US(Country):
                 "en": "Veterans Day",
                 "es": "Día de los Veteranos",
             }) \
-            .on(date(month=11, day=11)) \
+            .on(date(Month.NOVEMBER, 11)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -111,8 +111,8 @@ class US(Country):
                 "en": "Veterans Day (in lieu of)",
                 "es": "Día de los Veteranos (en lugar de)",
             }) \
-            .on(date(month=11, day=10)) \
-            .on_condition(date(month=11, day=11).is_a("saturday")) \
+            .on(date(Month.NOVEMBER, 10)) \
+            .on_condition(date(Month.NOVEMBER, 11).is_a(Weekday.SATURDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -120,8 +120,8 @@ class US(Country):
                 "en": "Veterans Day (in lieu of)",
                 "es": "Día de los Veteranos (en lugar de)",
             }) \
-            .on(date(month=11, day=12)) \
-            .on_condition(date(month=11, day=11).is_a("sunday")) \
+            .on(date(Month.NOVEMBER, 12)) \
+            .on_condition(date(Month.NOVEMBER, 11).is_a(Weekday.SUNDAY)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -129,8 +129,8 @@ class US(Country):
                 "en": "Christmas Eve",
                 "es": "Nochebuena",
             }) \
-            .on(date(month=12, day=24)) \
-            .on_condition(date(month=12, day=25).is_not_a("saturday")) \
+            .on(date(Month.DECEMBER, 24)) \
+            .on_condition(date(Month.DECEMBER, 25).is_not_a(Weekday.SATURDAY)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -138,7 +138,7 @@ class US(Country):
                 "en": "Christmas Day",
                 "es": "Navidad",
             }) \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -146,8 +146,8 @@ class US(Country):
                 "en": "Christmas Day (in lieu of)",
                 "es": "Navidad (en lugar de)",
             }) \
-            .on(date(month=12, day=24)) \
-            .on_condition(date(month=12, day=25).is_a("saturday")) \
+            .on(date(Month.DECEMBER, 24)) \
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SATURDAY)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -155,8 +155,8 @@ class US(Country):
                 "en": "Christmas Day (in lieu of)",
                 "es": "Navidad (en lugar de)",
             }) \
-            .on(date(month=12, day=26)) \
-            .on_condition(date(month=12, day=25).is_a("sunday")) \
+            .on(date(Month.DECEMBER, 26)) \
+            .on_condition(date(Month.DECEMBER, 25).is_a(Weekday.SUNDAY)) \
             .with_flags("NRF")
 
         self.define_holiday() \
@@ -164,7 +164,7 @@ class US(Country):
                 "en": "Birthday of Martin Luther King, Jr.",
                 "es": "Cumpleaños de Martin Luther King, Jr.",
             }) \
-            .on(third("monday").of("January")) \
+            .on(third(Weekday.MONDAY).of(Month.JANUARY)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -172,7 +172,7 @@ class US(Country):
                 "en": "Washington's Birthday",
                 "es": "Día del Presidente",
             }) \
-            .on(third("monday").of("february")) \
+            .on(third(Weekday.MONDAY).of(Month.FEBRUARY)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -181,7 +181,7 @@ class US(Country):
                 "es": "Día del Patriota",
                 }) \
             .in_regions(["MA", "ME"]) \
-            .on(third("monday").of("april")) \
+            .on(third(Weekday.MONDAY).of(Month.APRIL)) \
             .with_flags("V")
 
         self.define_holiday() \
@@ -189,7 +189,7 @@ class US(Country):
                 "en": "Memorial Day",
                 "es": "Día de los Caídos",
             }) \
-            .on(last("monday").of("may")) \
+            .on(last(Weekday.MONDAY).of(Month.MAY)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -197,7 +197,7 @@ class US(Country):
                 "en": "Labor Day",
                 "es": "Día del Trabajo",
             }) \
-            .on(first("monday").of("september")) \
+            .on(first(Weekday.MONDAY).of(Month.SEPTEMBER)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -205,7 +205,7 @@ class US(Country):
                 "en": "Columbus Day",
                 "es": "Día de Columbus",
             }) \
-            .on(second("monday").of("october")) \
+            .on(second(Weekday.MONDAY).of(Month.OCTOBER)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -213,7 +213,7 @@ class US(Country):
                 "en": "Thanksgiving Day",
                 "es": "Día de Acción de Gracias",
             }) \
-            .on(fourth("thursday").of("november")) \
+            .on(fourth(Weekday.THURSDAY).of(Month.NOVEMBER)) \
             .with_flags("NV")
 
         self.define_holiday() \
@@ -221,5 +221,5 @@ class US(Country):
                 "en": "Day after Thanksgiving",
                 "es": "Día después de Acción de Gracias",
             }) \
-            .on(day(1).after(fourth("thursday").of("november"))) \
+            .on(day(1).after(fourth(Weekday.THURSDAY).of(Month.NOVEMBER))) \
             .with_flags("NV")

--- a/src/holidata/holidays/ZA/__init__.py
+++ b/src/holidata/holidays/ZA/__init__.py
@@ -1,7 +1,7 @@
 from dateutil.easter import EASTER_WESTERN
 
 from holidata.holiday import Country
-from holidata.utils import day, date
+from holidata.utils import day, date, Weekday, Month
 
 __all__ = [
     "ZA",
@@ -18,7 +18,7 @@ class ZA(Country):
 
         self.define_holiday() \
             .with_name("Christmas Day") \
-            .on(date(month=12, day=25)) \
+            .on(date(Month.DECEMBER, 25)) \
             .with_flags("NF")
 
         self.define_holiday() \
@@ -33,108 +33,108 @@ class ZA(Country):
 
         self.define_holiday() \
             .with_name("New Year's Day") \
-            .on(date(month=1, day=1)) \
+            .on(date(Month.JANUARY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("New Year's Day (Supplement)") \
-            .on(date(month=1, day=2)) \
+            .on(date(Month.JANUARY, 2)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=1, day=1).is_a("sunday"))
+            .on_condition(date(Month.JANUARY, 1).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Human Rights Day") \
-            .on(date(month=3, day=21)) \
+            .on(date(Month.MARCH, 21)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Human Rights Day (Supplement)") \
-            .on(date(month=3, day=22)) \
+            .on(date(Month.MARCH, 22)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=3, day=21).is_a("sunday"))
+            .on_condition(date(Month.MARCH, 21).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Freedom Day") \
-            .on(date(month=4, day=27)) \
+            .on(date(Month.APRIL, 27)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Freedom Day (Supplement)") \
-            .on(date(month=4, day=28)) \
+            .on(date(Month.APRIL, 28)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=4, day=27).is_a("sunday"))
+            .on_condition(date(Month.APRIL, 27).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Worker's Day") \
-            .on(date(month=5, day=1)) \
+            .on(date(Month.MAY, 1)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Worker's Day (Supplement)") \
-            .on(date(month=5, day=2)) \
+            .on(date(Month.MAY, 2)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=5, day=1).is_a("sunday"))
+            .on_condition(date(Month.MAY, 1).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Youth Day") \
-            .on(date(month=6, day=16)) \
+            .on(date(Month.JUNE, 16)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Youth Day (Supplement)") \
-            .on(date(month=6, day=17)) \
+            .on(date(Month.JUNE, 17)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=6, day=16).is_a("sunday"))
+            .on_condition(date(Month.JUNE, 16).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("National Women's Day") \
-            .on(date(month=8, day=9)) \
+            .on(date(Month.AUGUST, 9)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("National Women's Day (Supplement)") \
-            .on(date(month=8, day=10)) \
+            .on(date(Month.AUGUST, 10)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=8, day=9).is_a("sunday"))
+            .on_condition(date(Month.AUGUST, 9).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Heritage Day") \
-            .on(date(month=9, day=24)) \
+            .on(date(Month.SEPTEMBER, 24)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Heritage Day (Supplement)") \
-            .on(date(month=9, day=25)) \
+            .on(date(Month.SEPTEMBER, 25)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=9, day=24).is_a("sunday"))
+            .on_condition(date(Month.SEPTEMBER, 24).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Day of Reconciliation") \
-            .on(date(month=12, day=16)) \
+            .on(date(Month.DECEMBER, 16)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Day of Reconciliation (Supplement)") \
-            .on(date(month=12, day=17)) \
+            .on(date(Month.DECEMBER, 17)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=12, day=16).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 16).is_a(Weekday.SUNDAY))
 
         self.define_holiday() \
             .with_name("Day of Goodwill") \
-            .on(date(month=12, day=26)) \
+            .on(date(Month.DECEMBER, 26)) \
             .with_flags("NF")
 
         self.define_holiday() \
             .with_name("Day of Goodwill (Supplement)") \
-            .on(date(month=12, day=27)) \
+            .on(date(Month.DECEMBER, 27)) \
             .with_flags("NF") \
             .annotated_with("Supplement holiday") \
-            .on_condition(date(month=12, day=26).is_a("sunday"))
+            .on_condition(date(Month.DECEMBER, 26).is_a(Weekday.SUNDAY))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,250 @@
+import pytest
+
+from holidata.utils import (
+    Weekday, Month, SmartDayArrow, SmartDayArrowWrapper, 
+    SmartDayArrowDayShifter, SmartDayArrowWeekdayShifter,
+    date, day, first, second, third, fourth, last
+)
+
+
+class TestWeekdayEnum:
+    def test_weekday_enum_values(self):
+        assert Weekday.MONDAY == 0
+        assert Weekday.TUESDAY == 1
+        assert Weekday.WEDNESDAY == 2
+        assert Weekday.THURSDAY == 3
+        assert Weekday.FRIDAY == 4
+        assert Weekday.SATURDAY == 5
+        assert Weekday.SUNDAY == 6
+
+
+class TestMonthEnum:
+    def test_month_enum_values(self):
+        assert Month.JANUARY == 1
+        assert Month.FEBRUARY == 2
+        assert Month.MARCH == 3
+        assert Month.APRIL == 4
+        assert Month.MAY == 5
+        assert Month.JUNE == 6
+        assert Month.JULY == 7
+        assert Month.AUGUST == 8
+        assert Month.SEPTEMBER == 9
+        assert Month.OCTOBER == 10
+        assert Month.NOVEMBER == 11
+        assert Month.DECEMBER == 12
+
+
+class TestSmartDayArrow:
+    def test_shift_to_weekday_forward_basic(self):
+        # 2023-01-01 is a Sunday
+        base_date = SmartDayArrow(2023, 1, 1)
+        # Get the first Monday after (2023-01-02)
+        result = base_date.shift_to_weekday(Weekday.MONDAY, order=1, reverse=False, including=False)
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 2
+        assert result.weekday() == Weekday.MONDAY
+
+    def test_shift_to_weekday_reverse_basic(self):
+        # 2023-01-01 is a Sunday
+        base_date = SmartDayArrow(2023, 1, 1)
+        # Get the first Saturday before (2023-12-31 of previous year)
+        result = base_date.shift_to_weekday(Weekday.SATURDAY, order=1, reverse=True, including=False)
+        assert result.year == 2022
+        assert result.month == 12
+        assert result.day == 31
+        assert result.weekday() == Weekday.SATURDAY
+
+    def test_shift_to_weekday_including_current(self):
+        # 2023-01-01 is a Sunday
+        base_date = SmartDayArrow(2023, 1, 1)
+        # Get the first Sunday including current date
+        result = base_date.shift_to_weekday(Weekday.SUNDAY, order=1, reverse=False, including=True)
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 1
+        assert result.weekday() == Weekday.SUNDAY
+
+    def test_shift_to_weekday_order_greater_than_one(self):
+        # 2023-01-01 is a Sunday
+        base_date = SmartDayArrow(2023, 1, 1)
+        # Get the second Monday after (2023-01-09)
+        result = base_date.shift_to_weekday(Weekday.MONDAY, order=2, reverse=False, including=False)
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 9
+        assert result.weekday() == Weekday.MONDAY
+
+    def test_shift_to_weekday_invalid_order(self):
+        base_date = SmartDayArrow(2023, 1, 1)
+        with pytest.raises(ValueError, match="Order must be greater than 0"):
+            base_date.shift_to_weekday(Weekday.MONDAY, order=0, reverse=False, including=False)
+
+        with pytest.raises(ValueError, match="Order must be greater than 0"):
+            base_date.shift_to_weekday(Weekday.MONDAY, order=-1, reverse=False, including=False)
+
+
+class TestSmartDayArrowWrapper:
+    def test_wrapper_creation(self):
+        wrapper = SmartDayArrowWrapper(Month.JANUARY, 1)
+        assert wrapper.month == 1
+        assert wrapper.day == 1
+
+    def test_wrapper_callable(self):
+        wrapper = SmartDayArrowWrapper(Month.JANUARY, 1)
+        result = wrapper(2023)
+        assert isinstance(result, SmartDayArrow)
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 1
+
+    def test_is_a_method(self):
+        wrapper = SmartDayArrowWrapper(Month.JANUARY, 2)  # 2023-01-02 is a Monday
+        predicate = wrapper.is_a(Weekday.MONDAY)
+        assert predicate(2023) is True
+        
+        predicate = wrapper.is_a(Weekday.TUESDAY)
+        assert predicate(2023) is False
+
+    def test_is_not_a_method(self):
+        wrapper = SmartDayArrowWrapper(Month.JANUARY, 2)  # 2023-01-02 is a Monday
+        predicate = wrapper.is_not_a(Weekday.TUESDAY)
+        assert predicate(2023) is True
+        
+        predicate = wrapper.is_not_a(Weekday.MONDAY)
+        assert predicate(2023) is False
+
+    def test_is_one_of_method(self):
+        wrapper = SmartDayArrowWrapper(Month.JANUARY, 2)  # 2023-01-02 is a Monday
+        predicate = wrapper.is_one_of([Weekday.MONDAY, Weekday.TUESDAY])
+        assert predicate(2023) is True
+        
+        predicate = wrapper.is_one_of([Weekday.TUESDAY, Weekday.WEDNESDAY])
+        assert predicate(2023) is False
+
+    def test_is_none_of_method(self):
+        wrapper = SmartDayArrowWrapper(Month.JANUARY, 2)  # 2023-01-02 is a Monday
+        predicate = wrapper.is_none_of([Weekday.TUESDAY, Weekday.WEDNESDAY])
+        assert predicate(2023) is True
+        
+        predicate = wrapper.is_none_of([Weekday.MONDAY, Weekday.TUESDAY])
+        assert predicate(2023) is False
+
+    def test_is_equal_to_method(self):
+        wrapper1 = SmartDayArrowWrapper(Month.JANUARY, 2)
+        wrapper2 = SmartDayArrowWrapper(Month.JANUARY, 2)
+        wrapper3 = SmartDayArrowWrapper(Month.JANUARY, 3)
+        
+        predicate = wrapper1.is_equal_to(wrapper2)
+        assert predicate(2023) is True
+        
+        predicate = wrapper1.is_equal_to(wrapper3)
+        assert predicate(2023) is False
+
+    def test_is_not_equal_to_method(self):
+        wrapper1 = SmartDayArrowWrapper(Month.JANUARY, 2)
+        wrapper2 = SmartDayArrowWrapper(Month.JANUARY, 2)
+        wrapper3 = SmartDayArrowWrapper(Month.JANUARY, 3)
+        
+        predicate = wrapper1.is_not_equal_to(wrapper3)
+        assert predicate(2023) is True
+        
+        predicate = wrapper1.is_not_equal_to(wrapper2)
+        assert predicate(2023) is False
+
+
+class TestDateFunction:
+    def test_date_function_creates_wrapper(self):
+        wrapper = date(Month.JANUARY, 1)
+        assert isinstance(wrapper, SmartDayArrowWrapper)
+        assert wrapper.month == 1
+        assert wrapper.day == 1
+
+
+class TestDayFunctionAndShifter:
+    def test_day_function_creates_shifter(self):
+        shifter = day(5)
+        assert isinstance(shifter, SmartDayArrowDayShifter)
+        assert shifter.day_count == 5
+
+    def test_day_shifter_before(self):
+        base_date_func = lambda year: SmartDayArrow(year, Month.JANUARY, 10)
+        shifter = day(3).before(base_date_func)
+        result = shifter(2023)
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 7  # 10 - 3 = 7
+
+    def test_day_shifter_after(self):
+        base_date_func = lambda year: SmartDayArrow(year, Month.JANUARY, 10)
+        shifter = day(3).after(base_date_func)
+        result = shifter(2023)
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 13  # 10 + 3 = 13
+
+
+class TestWeekdayShifter:
+    def test_first_weekday_shifter(self):
+        shifter = first(Weekday.MONDAY)
+        assert isinstance(shifter, SmartDayArrowWeekdayShifter)
+        assert shifter.weekday == Weekday.MONDAY
+        assert shifter.order == 1
+        assert shifter.forward is True
+
+    def test_second_weekday_shifter(self):
+        shifter = second(Weekday.TUESDAY)
+        assert isinstance(shifter, SmartDayArrowWeekdayShifter)
+        assert shifter.weekday == Weekday.TUESDAY
+        assert shifter.order == 2
+        assert shifter.forward is True
+
+    def test_third_weekday_shifter(self):
+        shifter = third(Weekday.WEDNESDAY)
+        assert isinstance(shifter, SmartDayArrowWeekdayShifter)
+        assert shifter.weekday == Weekday.WEDNESDAY
+        assert shifter.order == 3
+        assert shifter.forward is True
+
+    def test_fourth_weekday_shifter(self):
+        shifter = fourth(Weekday.THURSDAY)
+        assert isinstance(shifter, SmartDayArrowWeekdayShifter)
+        assert shifter.weekday == Weekday.THURSDAY
+        assert shifter.order == 4
+        assert shifter.forward is True
+
+    def test_last_weekday_shifter(self):
+        shifter = last(Weekday.FRIDAY)
+        assert isinstance(shifter, SmartDayArrowWeekdayShifter)
+        assert shifter.weekday == Weekday.FRIDAY
+        assert shifter.order == 1
+        assert shifter.forward is False
+
+    def test_weekday_shifter_of_method(self):
+        shifter = first(Weekday.MONDAY).of(Month.JANUARY)
+        result = shifter(2023)
+        # First Monday of January 2023 is 2023-01-02
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 2
+        assert result.weekday() == Weekday.MONDAY
+
+    def test_weekday_shifter_before_method(self):
+        base_date_func = lambda year: SmartDayArrow(year, Month.JANUARY, 15)
+        shifter = first(Weekday.MONDAY).before(base_date_func)
+        result = shifter(2023)
+        # First Monday before 2023-01-15 is 2023-01-09
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 9
+        assert result.weekday() == Weekday.MONDAY
+
+    def test_weekday_shifter_after_method(self):
+        base_date_func = lambda year: SmartDayArrow(year, Month.JANUARY, 15)
+        shifter = first(Weekday.MONDAY).after(base_date_func)
+        result = shifter(2023)
+        # First Monday after 2023-01-15 is 2023-01-16
+        assert result.year == 2023
+        assert result.month == 1
+        assert result.day == 16
+        assert result.weekday() == Weekday.MONDAY


### PR DESCRIPTION
Using enums instead of strings for month and weekday names should improve type safety and IDE support.